### PR TITLE
Issue 159 - Basic controls for strike jobs

### DIFF
--- a/projects/developer/src/app/system/strikes/component.html
+++ b/projects/developer/src/app/system/strikes/component.html
@@ -52,6 +52,12 @@
                         <i class="fa" [innerHtml]="strikeJobIcon"></i>
                         View Job Details ({{ selectedStrikeDetail.job.status }})
                     </a>
+                    <button pButton type="button" icon="fa fa-ban" class="ui-button-secondary"
+                            (click)="cancelJob(selectedStrikeDetail.job.id)" pTooltip="Cancel Job"
+                            *ngIf="!selectedStrikeDetail.job.is_superseded && selectedStrikeDetail.job.status !== 'COMPLETED' && selectedStrikeDetail.job.status !== 'CANCELED'"></button>
+                    <button pButton type="button" icon="fa fa-repeat" class="ui-button-secondary"
+                            (click)="requeueJob(selectedStrikeDetail.job.id)" pTooltip="Requeue Job"
+                            *ngIf="!selectedStrikeDetail.job.is_superseded && (selectedStrikeDetail.job.status === 'FAILED' || selectedStrikeDetail.job.status === 'CANCELED')"></button>
                 </dd>
                 <dt>Created:</dt>
                 <dd>

--- a/projects/developer/src/app/system/strikes/component.ts
+++ b/projects/developer/src/app/system/strikes/component.ts
@@ -10,6 +10,7 @@ import * as _ from 'lodash';
 import { RecipeTypesApiService } from '../../configuration/recipe-types/api.service';
 import { WorkspacesApiService } from '../workspaces/api.service';
 import { StrikesApiService } from './api.service';
+import { JobsApiService } from '../../processing/jobs/api.service';
 import { Strike } from './api.model';
 import { IngestFile } from '../../common/models/api.ingest-file.model';
 
@@ -59,7 +60,8 @@ export class StrikesComponent implements OnInit, OnDestroy {
         private messageService: MessageService,
         private recipeTypesApiService: RecipeTypesApiService,
         private workspacesApiService: WorkspacesApiService,
-        private strikesApiService: StrikesApiService
+        private strikesApiService: StrikesApiService,
+        private jobsApiService: JobsApiService
     ) {}
 
     private clampText() {
@@ -433,6 +435,22 @@ export class StrikesComponent implements OnInit, OnDestroy {
         } else {
             this.router.navigate([`/system/strikes/${strike.value.id}`]);
         }
+    }
+
+    requeueJob(jobId: number): void {
+        this.messageService.add({severity: 'success', summary: 'Job requeue has been requested'});
+        this.jobsApiService.requeueJobs({job_ids: [jobId]})
+            .subscribe(() => {}, err => {
+                this.messageService.add({severity: 'error', summary: 'Error requeuing job', detail: err.statusText});
+            });
+    }
+
+    cancelJob(jobId: number): void {
+        this.messageService.add({severity: 'success', summary: 'Job cancellation has been requested'});
+        this.jobsApiService.cancelJobs({job_ids: [jobId]})
+            .subscribe(() => {}, err => {
+                this.messageService.add({severity: 'error', summary: 'Error canceling job', detail: err.statusText});
+            });
     }
 
     ngOnInit() {


### PR DESCRIPTION
Fixes #159.

UI elements and logic are duplicated from jobs component, adding the buttons inline to the job link on the strike detail page.