### PR TITLE
Fix for SNI validation

### DIFF
--- a/docker/nginx-template.conf
+++ b/docker/nginx-template.conf
@@ -16,7 +16,7 @@
     location /${CONTEXT}/silo/ {
         proxy_pass ${SILO_BACKEND}/;
         proxy_redirect / /${CONTEXT}/silo/;
-        proxy_set_header Host $host;
+        proxy_ssl_server_name on;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -24,7 +24,7 @@ server {
     location /silo/ {
         proxy_pass ${SILO_BACKEND}/;
         proxy_redirect / /silo/;
-        proxy_set_header Host $host;
+        proxy_ssl_server_name on;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Resolves the issue with `/silo` proxy failing to serve anything when setting `SILO_BACKEND` to an HTTPS fronted Silo instance.