### PR TITLE
Issue 207 - recipe editor enhancements

### DIFF
--- a/projects/developer/src/app/app.module.ts
+++ b/projects/developer/src/app/app.module.ts
@@ -16,8 +16,8 @@ import { UtcDatepickerModule } from 'angular-utc-datepicker';
 import {
     AutoCompleteModule, ButtonModule, CalendarModule, ChartModule, CheckboxModule, ChipsModule, ColorPickerModule, ConfirmationService,
     DataListModule, DialogModule, DropdownModule, InputSwitchModule, InputTextModule, InputTextareaModule, ListboxModule, MenubarModule,
-    MessagesModule, MultiSelectModule, OverlayPanelModule, PaginatorModule, PanelModule, ScrollPanelModule, SidebarModule, SpinnerModule,
-    StepsModule, TabViewModule, ToggleButtonModule, TooltipModule, TreeTableModule, SlideMenuModule
+    MessagesModule, MultiSelectModule, OverlayPanelModule, PaginatorModule, PanelModule, ScrollPanelModule, SidebarModule, SliderModule,
+    SpinnerModule, StepsModule, TabViewModule, ToggleButtonModule, TooltipModule, TreeTableModule, SlideMenuModule
 } from 'primeng/primeng';
 import { AccordionModule } from 'primeng/accordion';
 import { CardModule } from 'primeng/card';
@@ -178,6 +178,7 @@ const appInitializer = (appConfig: AppConfigService) => {
         SeedImagesModule,
         SidebarModule,
         SlideMenuModule,
+        SliderModule,
         SpinnerModule,
         StepsModule,
         TableModule,

--- a/projects/developer/src/app/common/components/recipe-graph/component.html
+++ b/projects/developer/src/app/common/components/recipe-graph/component.html
@@ -1,6 +1,34 @@
 <div class="p-grid" xmlns:svg="http://www.w3.org/1999/html">
     <div class="p-col-12 p-col-nopad">
         <p-menubar [model]="menuBarItems" [style]="{'margin-bottom':'0'}">
+            <div class="ui-inputgroup">
+                <button
+                    pButton
+                    icon="fa fa-search-minus"
+                    class="ui-button-secondary ui-inputgroup-addon"
+                    [disabled]="zoomLevel <= minZoomLevel"
+                    (click)="zoomOut()"
+                    type="button">
+                </button>
+                <div style="min-width: 16em; padding: 1.5em 0.5em;">
+                    <p-slider
+                        [(ngModel)]="zoomLevel"
+                        [min]="minZoomLevel"
+                        [max]="maxZoomLevel"
+                        [step]="zoomStep"
+                        [animate]="true"
+                        (onChange)="onZoomSliderChange($event)">
+                    </p-slider>
+                </div>
+                <button
+                    pButton
+                    icon="fa fa-search-plus"
+                    class="ui-button-secondary ui-inputgroup-addon"
+                    [disabled]="zoomLevel >= maxZoomLevel"
+                    (click)="zoomIn()"
+                    type="button">
+                </button>
+            </div>
         </p-menubar>
 
         <div class="recipe-container" [style.minHeight]="minHeight">
@@ -12,6 +40,11 @@
                 [orientation]="orientation"
                 [curve]="curve"
                 (select)="select($event)"
+                (zoomChange)="onZoomChange($event)"
+                [(zoomLevel)]="zoomLevel"
+                [minZoomLevel]="minZoomLevel"
+                [maxZoomLevel]="maxZoomLevel"
+                [zoomSpeed]="zoomStep"
                 [zoomToFit$]="zoomToFit"
                 [center$]="center"
                 [update$]="update">

--- a/projects/developer/src/app/common/components/recipe-graph/component.html
+++ b/projects/developer/src/app/common/components/recipe-graph/component.html
@@ -1,5 +1,8 @@
 <div class="p-grid" xmlns:svg="http://www.w3.org/1999/html">
     <div class="p-col-12 p-col-nopad">
+        <p-menubar [model]="menuBarItems" [style]="{'margin-bottom':'0'}">
+        </p-menubar>
+
         <div class="recipe-container" [style.minHeight]="minHeight">
             <ngx-graph
                 class="chart-container"
@@ -8,7 +11,10 @@
                 [nodes]="nodes"
                 [orientation]="orientation"
                 [curve]="curve"
-                (select)="select($event)">
+                (select)="select($event)"
+                [zoomToFit$]="zoomToFit"
+                [center$]="center"
+                [update$]="update">
 
                 <ng-template #defsTemplate>
                     <svg:marker id="arrow" viewBox="0 -5 10 10" refX="8" refY="0" markerWidth="4" markerHeight="4" orient="auto">
@@ -99,7 +105,7 @@
         </span>
         <span *ngIf="selectedCondition">
             <strong>{{ selectedCondition.name }}</strong>
-        </span>  
+        </span>
     </p-header>
     <div *ngIf="jobMetrics && metricTotal > 0">
         <div class="dialog-content">

--- a/projects/developer/src/app/common/components/recipe-graph/component.ts
+++ b/projects/developer/src/app/common/components/recipe-graph/component.ts
@@ -14,6 +14,10 @@ import { MessageService } from 'primeng/components/common/messageservice';
     styleUrls: ['./component.scss']
 })
 export class RecipeGraphComponent implements OnInit, OnChanges, AfterViewInit {
+    readonly minZoomLevel = 0.5;
+    readonly maxZoomLevel = 2.0;
+    readonly zoomStep = 0.1;
+
     @Input() recipeData: any;
     @Input() isEditing: boolean;
     @Input() jobMetrics: any;
@@ -43,6 +47,7 @@ export class RecipeGraphComponent implements OnInit, OnChanges, AfterViewInit {
     recipeDialogY: number;
     metricData: any;
     metricTotal = 0;
+    zoomLevel = 1;
     zoomToFit: Subject<boolean> = new Subject();
     center: Subject<boolean> = new Subject();
     update: Subject<boolean> = new Subject();
@@ -108,6 +113,38 @@ export class RecipeGraphComponent implements OnInit, OnChanges, AfterViewInit {
         }
         event.stopPropagation();
         return false;
+    }
+
+    /**
+     * Event when the zoom level has changed, fired by the graph component.
+     * @param  event new zoom level amount
+     */
+    onZoomChange(event: any): void {
+        this.zoomLevel = event;
+    }
+
+    /**
+     * Event for when the zoom slider changes, updates the graph.
+     * @param  event event containing originalEvent and value
+     */
+    onZoomSliderChange(event: any): void {
+        this.update.next(true);
+    }
+
+    /**
+     * Zooms out the graph by one zoom step level.
+     */
+    zoomOut(): void {
+        this.zoomLevel = Math.max(this.minZoomLevel, this.zoomLevel - this.zoomStep);
+        this.update.next(true);
+    }
+
+    /**
+     * Zooms in the graph by one zoom step level.
+     */
+    zoomIn(): void {
+        this.zoomLevel = Math.min(this.maxZoomLevel, this.zoomLevel + this.zoomStep);
+        this.update.next(true);
     }
 
     private verifyNode(node) {

--- a/projects/developer/src/app/common/components/recipe-graph/component.ts
+++ b/projects/developer/src/app/common/components/recipe-graph/component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, ViewChild, HostListener } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, AfterViewInit, ViewChild, HostListener } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { Subject } from 'rxjs';
 import * as shape from 'd3-shape';
@@ -13,7 +13,7 @@ import { MessageService } from 'primeng/components/common/messageservice';
     templateUrl: './component.html',
     styleUrls: ['./component.scss']
 })
-export class RecipeGraphComponent implements OnInit, OnChanges {
+export class RecipeGraphComponent implements OnInit, OnChanges, AfterViewInit {
     @Input() recipeData: any;
     @Input() isEditing: boolean;
     @Input() jobMetrics: any;
@@ -779,5 +779,14 @@ export class RecipeGraphComponent implements OnInit, OnChanges {
     }
 
     ngOnInit() {
+    }
+
+    ngAfterViewInit() {
+        // reset the viewport outside of lifecycle hooks
+        setTimeout(() => {
+            this.zoomToFit.next(true);
+            this.center.next(true);
+            this.update.next(true);
+        }, 0);
     }
 }

--- a/projects/developer/src/app/common/components/recipe-graph/component.ts
+++ b/projects/developer/src/app/common/components/recipe-graph/component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, ViewChild, HostListener } from '@angular/core';
 import * as shape from 'd3-shape';
 import * as _ from 'lodash';
 
@@ -73,6 +73,22 @@ export class RecipeGraphComponent implements OnInit, OnChanges {
         this.orientation = 'TB';
         this.curve = shape.curveBundle.beta(1);
         this.showLegend = false;
+    }
+
+    /**
+     * Catches the MozMousePixelScroll event, which is not currently captured in ngx-graph.
+     * Although deprecated, latest Firefox is still throwing this event. Disable it to prevent
+     * page scrolling (event is thrown when zooming in the graph component).
+     * @param  event MozMousePixelScroll event
+     * @return       status of event
+     */
+    @HostListener('MozMousePixelScroll', ['$event'])
+    onMozMouseWheel(event: any): boolean {
+        if (event.preventDefault) {
+            event.preventDefault();
+        }
+        event.stopPropagation();
+        return false;
     }
 
     private verifyNode(node) {

--- a/projects/developer/src/app/common/components/recipe-graph/component.ts
+++ b/projects/developer/src/app/common/components/recipe-graph/component.ts
@@ -1,4 +1,6 @@
 import { Component, Input, OnChanges, OnInit, ViewChild, HostListener } from '@angular/core';
+import { MenuItem } from 'primeng/api';
+import { Subject } from 'rxjs';
 import * as shape from 'd3-shape';
 import * as _ from 'lodash';
 
@@ -41,6 +43,9 @@ export class RecipeGraphComponent implements OnInit, OnChanges {
     recipeDialogY: number;
     metricData: any;
     metricTotal = 0;
+    zoomToFit: Subject<boolean> = new Subject();
+    center: Subject<boolean> = new Subject();
+    update: Subject<boolean> = new Subject();
     chartOptions: any = {
         legend: {
             display: false
@@ -63,6 +68,20 @@ export class RecipeGraphComponent implements OnInit, OnChanges {
             }
         }
     };
+    menuBarItems: MenuItem[] = [
+        { label: 'Reset zoom', icon: 'fa fa-compress',
+            command: () => {
+                this.zoomToFit.next(true);
+            }
+        },
+        { label: 'Center graph', icon: 'fa fa-align-center',
+            command: () => {
+                this.center.next(true);
+                this.update.next(true);
+            }
+        },
+    ];
+
     constructor(
         private jobsApiService: JobsApiService,
         private messageService: MessageService,


### PR DESCRIPTION
Closes #207 

In this PR:
- prevents page scrolling in Firefox when zooming in on graph
- add buttons to fit zoom and recenter
    - activate these two features when the page first loads
- adds a slider/buttons for easier zooming

Not going to do:
- delete button on either the node itself or the associated popup - workflow will probably be changing at some point
- dragging a node to a new position results in the popup opening - no way to prevent this with the options currently exposed in ngx-graph (open issue and PR in their repo to address)