### PR TITLE
Issue 233 - Pass down environment variables into appConfig.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,18 @@ LABEL \
     SOURCE="https://github.com/ngageoint/scale-ui" \
     DESCRIPTION="UI for Scale processing framework for containerized algorithms"
 
-RUN apk -U --no-cache add jq && chmod 777 /usr/share/nginx/html
+RUN apk -U --no-cache add jq bash && chmod 777 /usr/share/nginx/html
 
 ENV CONFIG_JSON=/usr/share/nginx/html/assets/appConfig.json
 ENV NGINX_CONF=/etc/nginx/conf.d/default.conf
 ENV API_URL=http://scale-webserver.marathon.l4lb.thisdcos.directory:80/
+ENV SILO_URL=http://scale-silo.marathon.l4lb.thisdcos.directory:9000/
 
 COPY dist/developer /usr/share/nginx/html
 COPY docker/nginx.conf ${NGINX_CONF}
 COPY docker/nginx-template.conf /
 COPY docker/docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh && chmod 777 ${CONFIG_JSON} 
+RUN chmod +x /docker-entrypoint.sh && chmod 777 ${CONFIG_JSON}
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-: ${API_URL_OVERRIDE:=/api}
-: ${AUTH_URL:=/api/login/}
-: ${AUTH_ENABLED:=true}
-: ${SILO_URL_OVERRIDE:=/silo}
+# ------------------------------------------------------------------------------
+# 1) prepare env vars for nginx
+# ------------------------------------------------------------------------------
+# used for nginx replacements
 : ${SILO_URL:=http://scale-silo.marathon.l4lb.thisdcos.directory:9000/}
 : ${API_URL:=http://scale-webserver.marathon.l4lb.thisdcos.directory:80/}
 
@@ -11,59 +11,45 @@
 SILO_URL=$(echo ${SILO_URL} | sed 's^/$^^')
 API_URL=$(echo ${API_URL} | sed 's^/$^^')
 
-jq_in_place() {
-    tmp=$(mktemp)
-    jq $1 $2 > ${tmp}
-    mv ${tmp} $2
-}
 
-# Ensure valid all lower case true/false value for AUTH_ENABLED
-AUTH_CLEANED=$(echo ${AUTH_ENABLED} | tr '[:upper:]' '[:lower:]')
+# ------------------------------------------------------------------------------
+# 2) load all prefixed env vars into the appconfig file
+# ------------------------------------------------------------------------------
+# open the existing appconfig json file
+json_data=`cat "$CONFIG_JSON"`
 
-jq_in_place '.apiPrefix="'${API_URL_OVERRIDE}'"' ${CONFIG_JSON}
-jq_in_place '.auth.scheme.url="'${AUTH_URL}'"' ${CONFIG_JSON}
-jq_in_place '.auth.enabled='${AUTH_CLEANED}'' ${CONFIG_JSON}
-jq_in_place '.siloUrl="'${SILO_URL_OVERRIDE}'"' ${CONFIG_JSON}
+# only look at environment variables with this prefix
+PREFIX="SCALEUI_"
+prefix_len=${#PREFIX}
+env_names=`compgen -A variable | grep "^$PREFIX"`
 
-# We support duplicating the assets from the root to any number of contexts
-# This is necessary as Scale is served from DCOS at various contexts with one container.
-# The front-end Angular routes need to know what their base HREF is and the only way we've
-# discovered to accomplish this is to make them available individually with their own
-# unique HREF. Nginx doesn't care what we do as long as they live under the web root, so we just
-# duplicate and shim.
-if [[ "${CONTEXTS}x" != "x" ]]
-then
-    WEB_ROOT=/usr/share/nginx/html
-    chmod -R 755 ${WEB_ROOT}
-    cp -R ${WEB_ROOT} /tmp/
+# loop over each prefixed env var name
+for full_name in $env_names; do
+    # get only the name after the prefix
+    name=${full_name:$prefix_len}
 
-    ITEMS=$(echo ${CONTEXTS} | tr "," "\n")
+    # make lowercase
+    name=`echo "$name" | tr '[:upper:]' '[:lower:]'`
 
-    for ITEM in ${ITEMS}
-    do
-        # Strip leading and trailing slashes
-	ITEM=$(echo ${ITEM} | sed 's~/$~~' | sed 's~^/~~')
-        echo "Creating instance of Scale UI at $WEB_ROOT/$ITEM..."
-        mkdir -p $WEB_ROOT/$ITEM
-        cp -R /tmp/html/* $WEB_ROOT/$ITEM/
+    # get the value
+    value=${!full_name}
 
-        ITEM_CONFIG_JSON=$WEB_ROOT/$ITEM/assets/appConfig.json
-        cp ${CONFIG_JSON} ${ITEM_CONFIG_JSON}
+    # add or replace the variable
+    json_data=`echo "$json_data" | jq -r --arg value "$value" ".$name=\"$value\""`
+done
 
-        jq_in_place '.apiPrefix="/'${ITEM}${API_URL_OVERRIDE}'"' ${ITEM_CONFIG_JSON}
-        jq_in_place '.siloUrl="/'${ITEM}${SILO_URL_OVERRIDE}'"' ${ITEM_CONFIG_JSON}
-        jq_in_place '.auth.scheme.url="/'${ITEM}${AUTH_URL}'"' ${ITEM_CONFIG_JSON}
-        cat /tmp/html/index.html | sed 's^base href="\/"^base href="/'${ITEM}'\/"^g' > $WEB_ROOT/$ITEM/index.html
-        chmod 755 ${ITEM_CONFIG_JSON}
-        # Adding contexts for backend
-        (cat /nginx-template.conf | sed 's^${CONTEXT}^'${ITEM}'^g' | sed 's^${API_URL}^'${API_URL}'^g' | sed 's^${SILO_URL}^'${SILO_URL}'^g' ) >> ${NGINX_CONF}
-    done
-fi
+# save the replaced json back to the file
+echo "$json_data" > "$CONFIG_JSON"
 
+
+# ------------------------------------------------------------------------------
+# 3) replacements for nginx.conf
+# ------------------------------------------------------------------------------
 # Update the nginx conf with the backend for Scale
 cat ${NGINX_CONF} | sed 's^${API_URL}^'${API_URL}'^g' | sed 's^${SILO_URL}^'${SILO_URL}'^g' > /tmp/nginx.conf
 mv /tmp/nginx.conf ${NGINX_CONF}
 # Terminate NGINX conf file
 echo "}" >> ${NGINX_CONF}
+
 
 exec "$@"

--- a/projects/developer/src/app/app.component.ts
+++ b/projects/developer/src/app/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit {
         this.theme = localStorage.getItem(environment.themeKey) || environment.defaultTheme;
         this.themeService.setTheme(this.theme);
 
-        if (environment.auth.enabled) {
+        if (environment.authEnabled) {
             this.loading = true;
             this.profileService.getProfile().subscribe(data => {
                 this.loading = false;
@@ -40,12 +40,12 @@ export class AppComponent implements OnInit {
                     this.isAuthenticated = true;
                 } else {
                     // attempt to authenticate
-                    if (environment.auth.scheme.type === 'geoaxis') {
+                    if (environment.authSchemeType === 'geoaxis') {
                         // redirect to geoaxis login
                         this.header = 'Authentication is Required';
                         this.message = 'Redirecting to GEOAxIS...';
-                        window.location.href = `${environment.auth.scheme.url}http://127.0.0.1:8080`;
-                    } else if (environment.auth.scheme.type === 'form') {
+                        window.location.href = `${environment.authSchemeUrl}http://127.0.0.1:8080`;
+                    } else if (environment.authSchemeType === 'form') {
                         // show login form
                         this.header = 'Authentication is Required';
                         this.message = 'Enter your username and password to continue.';
@@ -55,18 +55,18 @@ export class AppComponent implements OnInit {
                         this.header = 'Authentication is Required';
                         this.message = 'Redirecting to login form...';
                         setTimeout(() => {
-                            window.location.href = `${environment.auth.scheme.url}?next=${window.location.href}`;
+                            window.location.href = `${environment.authSchemeUrl}?next=${window.location.href}`;
                         }, 3000);
                     }
                 }
             }, err => {
                 this.loading = false;
                 console.log(err);
-                if (environment.auth.scheme.type === 'geoaxis') {
+                if (environment.authSchemeType === 'geoaxis') {
                     this.header = 'Authentication is Required';
                     this.message = 'Redirecting to GEOAxIS...';
-                    window.location.href = `${environment.auth.scheme.url}${window.location.href}`;
-                } else if (environment.auth.scheme.type === 'form') {
+                    window.location.href = `${environment.authSchemeUrl}${window.location.href}`;
+                } else if (environment.authSchemeType === 'form') {
                     // GET call to retrieve CSRF cookie
                     this.profileService.getLogin().subscribe(data => {
                         console.log(data);
@@ -86,7 +86,7 @@ export class AppComponent implements OnInit {
                     this.header = 'Authentication is Required';
                     this.message = 'Redirecting to login form...';
                     setTimeout(() => {
-                        window.location.href = `${environment.auth.scheme.url}?next=${window.location.href}`;
+                        window.location.href = `${environment.authSchemeUrl}?next=${window.location.href}`;
                     }, 3000);
                 }
             });

--- a/projects/developer/src/app/common/services/app-config.service.ts
+++ b/projects/developer/src/app/common/services/app-config.service.ts
@@ -14,22 +14,23 @@ export class AppConfigService {
         private themeService: ThemeService
     ) {}
 
-    loadAppConfig(path: string) {
+    loadAppConfig(path: string): Promise<any> {
         return this.http.get(path)
             .toPromise()
             .then((data: any) => {
-                environment.apiDefaultVersion = data.apiDefaultVersion;
-                environment.apiPrefix = data.apiPrefix;
-                environment.apiVersions = data.apiVersions;
-                environment.auth = data.auth;
-                environment.dateFormat = data.dateFormat;
-                environment.defaultTheme = data.defaultTheme;
-                environment.documentation = data.documentation;
-                environment.siloUrl = data.siloUrl;
-                environment.themeKey = data.themeKey;
-                environment.primaryColor = data.primaryColor;
-                environment.secondaryLightColor = data.secondaryLightColor;
-                environment.secondaryDarkColor = data.secondaryDarkColor;
+                // loop over all keys in the appconfig.json file
+                Object.keys(data).forEach(key => {
+                    // try to parse the values as json
+                    let value = data[key];
+                    try {
+                        value = JSON.parse(value);
+                    } catch (e) {
+                        // ignore, not valid json value so default to original
+                    }
+
+                    // set the camelcased version of the key in environments
+                    environment[_.camelCase(key)] = value;
+                });
 
                 // update themes with values from config
                 const themes = this.themeService.getThemes();

--- a/projects/developer/src/app/common/services/profile.service.ts
+++ b/projects/developer/src/app/common/services/profile.service.ts
@@ -12,7 +12,7 @@ import { DataService } from './data.service';
 })
 export class ProfileService {
     apiPrefix: string;
-    isAuthenticated = new BehaviorSubject(!environment.auth.enabled);
+    isAuthenticated = new BehaviorSubject(!environment.authEnabled);
 
     constructor(
         private http: HttpClient
@@ -41,14 +41,14 @@ export class ProfileService {
     }
 
     getLogin(): Observable<any> {
-        return this.http.get<any>(`${environment.auth.scheme.url}`)
+        return this.http.get<any>(`${environment.authSchemeUrl}`)
             .pipe(
                 catchError(DataService.handleError)
             );
     }
 
     login(data): Observable<any> {
-        return this.http.post<any>(`${environment.auth.scheme.url}`, data)
+        return this.http.post<any>(`${environment.authSchemeUrl}`, data)
             .pipe(
                 catchError(DataService.handleError)
             );

--- a/projects/developer/src/app/footer/footer.component.html
+++ b/projects/developer/src/app/footer/footer.component.html
@@ -1,6 +1,6 @@
 <div class="footer">
-    <div *ngIf="!env.auth.enabled"></div>
-    <ul *ngIf="env.auth.enabled">
+    <div *ngIf="!env.authEnabled"></div>
+    <ul *ngIf="env.authEnabled">
         <li *ngIf="userProfile">
             <strong>Authenticated User:</strong> {{ userProfile.first_name }} {{ userProfile.last_name }}
         </li>
@@ -16,7 +16,7 @@
 </div>
 <p-overlayPanel styleClass="footer__profile-overlaypanel" appendTo="body" [dismissable]="true"
                 (onShow)="handleOnProfileShow()" #profileOp>
-    <div class="footer__profile-login" *ngIf="!isAuthenticated && env.auth.scheme.type === 'form'">
+    <div class="footer__profile-login" *ngIf="!isAuthenticated && env.authSchemeType === 'form'">
         <input pInputText type="text" placeholder="Username" [(ngModel)]="username" (keypress)="handleKeyPress($event)"
                #user/>
         <input pInputText type="password" placeholder="Password" [(ngModel)]="password"
@@ -24,7 +24,7 @@
         <button pButton type="button" class="ui-button-secondary" icon="fa fa-sign-in" label="Login" (click)="login()"
                 [disabled]="!username || !password"></button>
     </div>
-    <div *ngIf="!isAuthenticated && env.auth.scheme.type === 'external'">
-        <a [href]="env.auth.scheme.url"><i class="fa fa-external-link"></i> Continue to login</a>
+    <div *ngIf="!isAuthenticated && env.authSchemeType === 'external'">
+        <a [href]="env.authSchemeUrl"><i class="fa fa-external-link"></i> Continue to login</a>
     </div>
 </p-overlayPanel>

--- a/projects/developer/src/app/footer/footer.component.ts
+++ b/projects/developer/src/app/footer/footer.component.ts
@@ -50,7 +50,7 @@ export class FooterComponent implements OnInit, OnChanges {
     }
 
     handleOnProfileShow() {
-        if (!this.isAuthenticated && environment.auth.scheme.type === 'form') {
+        if (!this.isAuthenticated && environment.authSchemeType === 'form') {
             setTimeout(() => {
                 this.usernameEl.nativeElement.focus();
             }, 50);

--- a/projects/developer/src/assets/appConfig.json
+++ b/projects/developer/src/assets/appConfig.json
@@ -2,13 +2,9 @@
     "apiDefaultVersion": "v6",
     "apiPrefix": "/mocks",
     "apiVersions": [],
-    "auth": {
-        "enabled": false,
-        "scheme": {
-            "type": "external",
-            "url": ""
-        }
-    },
+    "authEnabled": false,
+    "authSchemeType": "external",
+    "authSchemeUrl": "/api/login/",
     "dateFormat": "YYYY-MM-DD HH:mm:ss[Z]",
     "defaultTheme": "light",
     "documentation": "http://ngageoint.github.io/scale/docs/index.html",

--- a/projects/developer/src/environments/environment.prod.ts
+++ b/projects/developer/src/environments/environment.prod.ts
@@ -6,13 +6,9 @@ export const environment = {
     apiDefaultVersion: '',
     apiPrefix: '',
     apiVersions: [],
-    auth: {
-        enabled: false,
-        scheme: {
-            type: '',
-            url: ''
-        }
-    },
+    authEnabled: false,
+    authSchemeType: '',
+    authSchemeUrl: '',
     dateFormat: '',
     defaultTheme: '',
     documentation: '',

--- a/projects/developer/src/environments/environment.ts
+++ b/projects/developer/src/environments/environment.ts
@@ -10,13 +10,9 @@ export const environment = {
     apiDefaultVersion: '',
     apiPrefix: '',
     apiVersions: [],
-    auth: {
-        enabled: false,
-        scheme: {
-            type: '',
-            url: ''
-        }
-    },
+    authEnabled: false,
+    authSchemeType: '',
+    authSchemeUrl: '',
     dateFormat: '',
     defaultTheme: '',
     documentation: '',


### PR DESCRIPTION
- flattens the auth section in appConfig.json
- redo docker-entrypoint.sh
  - Jonathan said we no longer need all the logic for multiple contexts (app will always be at root of webserver endpoint)
  - takes all environment variables prefixed with SCALEUI_, removes the prefix, and places it into appConfig.json
  - bash is used because I couldn't figure out parameter expansion without it
- app-config.service.ts now just loads anything in appConfig.json, camelCases the key, and loads it into environments.ts
- moves an env var from appConfig.json to the Dockerfile, and installs bash