### PR TITLE
Issue 256 - use values injected into the environment file rather than raw values

### DIFF
--- a/projects/developer/src/app/common/services/app-config.service.ts
+++ b/projects/developer/src/app/common/services/app-config.service.ts
@@ -31,15 +31,14 @@ export class AppConfigService {
                     // set the camelcased version of the key in environments
                     environment[_.camelCase(key)] = value;
                 });
-
                 // update themes with values from config
                 const themes = this.themeService.getThemes();
                 _.forEach(themes, theme => {
                     if (theme) {
                         this.themeService.updateTheme(theme.name, {
-                            '--scale-primary': data.primaryColor,
-                            '--scale-secondary-light': data.secondaryLightColor,
-                            '--scale-secondary-dark': data.secondaryDarkColor
+                            '--scale-primary': environment.primaryColor,
+                            '--scale-secondary-light': environment.secondaryLightColor,
+                            '--scale-secondary-dark': environment.secondaryDarkColor
                         });
                     }
                 });


### PR DESCRIPTION
Left out from #255. The raw values from appConfig.json were used instead of the values after the parsing step.

In the case of primary color, the appConfig.json already has `primaryColor`, but the docker script that converts the env var (`SCALEUI_PRIMARY_COLOR`) leaves it as `primary_color` in the appConfig.json. The loop that merged the values into `environments` also camel cases the keys, so `primary_color` overrides `primaryColor`.