### PR TITLE
Issue 262 - check if definition exists before looping over nodes

### DIFF
--- a/projects/developer/src/app/configuration/recipe-types/api.model.ts
+++ b/projects/developer/src/app/configuration/recipe-types/api.model.ts
@@ -118,15 +118,17 @@ export class RecipeType {
         public deprecated: string,
         public last_modified: string
     ) {
-        _.forEach(_.keys(this.definition.nodes), key => {
-            if (this.definition.nodes[key].node_type.node_type === 'condition') {
-                const c = RecipeTypeCondition.transformer({
-                    name: key,
-                    condition_interface: this.definition.nodes[key].node_type.interface,
-                    data_filter: this.definition.nodes[key].node_type.data_filter
-                });
-                this.conditions.push(c);
-            }
-        });
+        if (this.definition && this.definition.nodes) {
+            _.forEach(_.keys(this.definition.nodes), key => {
+                if (this.definition.nodes[key].node_type.node_type === 'condition') {
+                    const c = RecipeTypeCondition.transformer({
+                        name: key,
+                        condition_interface: this.definition.nodes[key].node_type.interface,
+                        data_filter: this.definition.nodes[key].node_type.data_filter
+                    });
+                    this.conditions.push(c);
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Closes #262 

`definition` has type any, so this is just adding a simple if-check prior to building condition nodes. The diff is just from alignment.