### PR TITLE
Issue 90 - notifications and icons for when a job will not be retried

### DIFF
--- a/api/handlers/jobs.js
+++ b/api/handlers/jobs.js
@@ -55,7 +55,8 @@ module.exports = function (request) {
                 category: 'none',
                 description: 'This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. This is just a test error to see what it looks like in the jobs table. '
             },
-            num_exes: 94,
+            max_tries: 3,
+            num_exes: Math.floor(Math.random() * (10 - 1 + 1) + 1),
             input_file_size: 79.8,
             source_started: '2015-08-28T17:55:41.005Z',
             source_ended: '2015-08-28T17:56:41.005Z',

--- a/projects/developer/src/app/processing/jobs/api.model.ts
+++ b/projects/developer/src/app/processing/jobs/api.model.ts
@@ -22,6 +22,7 @@ export class Job {
     exeEndedTooltip: any;
     inputJson: any;
     outputJson: any;
+    notRetriedTooltip = ''
 
     private static build(data) {
         if (data) {
@@ -126,5 +127,9 @@ export class Job {
         this.exeEndedTooltip = this.execution ? DataService.formatDate(this.execution.ended) : null;
         this.inputJson = this.input ? _.keys(this.input.json).length > 0 ? JSON.stringify(this.input.json, null, 2) : null : null;
         this.outputJson = this.output ? _.keys(this.output.json).length > 0 ? JSON.stringify(this.output.json, null, 2) : null : null;
+
+        if (this.num_exes === this.max_tries) {
+            this.notRetriedTooltip = 'Number of executions has been reached, cannot be retried';
+        }
     }
 }

--- a/projects/developer/src/app/processing/jobs/component.html
+++ b/projects/developer/src/app/processing/jobs/component.html
@@ -70,6 +70,9 @@
                     <div class="warning-text" *ngIf="rowData.job_type.unmet_resources">
                         <span class="fa fa-warning" [pTooltip]="rowData.job_type.unmetResourcesTooltip"></span>
                     </div>
+                    <div class="warning-text" *ngIf="rowData.notRetriedTooltip">
+                        <span class="fa fa-warning" [pTooltip]="rowData.notRetriedTooltip"></span>
+                    </div>
                 </div>
                 <div *ngSwitchCase="'recipe'">
                     <div *ngIf="rowData.recipe">

--- a/projects/developer/src/app/processing/jobs/details.component.ts
+++ b/projects/developer/src/app/processing/jobs/details.component.ts
@@ -47,6 +47,16 @@ export class JobDetailsComponent implements OnInit, OnDestroy {
         if (this.selectedJobExe && this.job.execution.id === this.selectedJobExe.id) {
             this.selectedJobExe = _.clone(this.job.execution);
         }
+
+        if (data.notRetriedTooltip) {
+            this.messageService.add({
+                severity: 'warn',
+                summary: 'Job not retriable',
+                detail: data.notRetriedTooltip,
+                closable: true,
+            });
+        }
+
         const now = moment.utc();
         const lastStatus = this.job.last_status_change ? moment.utc(this.job.last_status_change) : null;
         this.jobStatus = lastStatus ? `${_.capitalize(this.job.status)} ${lastStatus.from(now)}` : _.capitalize(this.job.status);


### PR DESCRIPTION
Closes #90 

This puts an icon in the jobs table page, as well as opening a warning notification when navigating to the job details page.