### PR TITLE
Remove recipe rev from strikes and scans

### DIFF
--- a/projects/developer/src/app/system/scans/details.component.ts
+++ b/projects/developer/src/app/system/scans/details.component.ts
@@ -123,7 +123,6 @@ export class ScanDetailsComponent implements OnInit, OnDestroy {
                     label: recipe.title,
                     value: {
                         name: recipe.name,
-                        revision_num: recipe.revision_num
                     }
                 });
             });

--- a/projects/developer/src/app/system/strikes/component.ts
+++ b/projects/developer/src/app/system/strikes/component.ts
@@ -162,7 +162,6 @@ export class StrikesComponent implements OnInit, OnDestroy {
                     label: recipe.title,
                     value: {
                         name: recipe.name,
-                        revision_num: recipe.revision_num
                     }
                 });
             });


### PR DESCRIPTION
Removed the `revision_num` to ensure that the most recent version of a recipe is used when triggering a recipe.