### PR TITLE
Recipe auto update

### DIFF
--- a/projects/developer/src/app/configuration/recipe-types/component.html
+++ b/projects/developer/src/app/configuration/recipe-types/component.html
@@ -83,13 +83,7 @@
                             <textarea pInputTextarea formControlName="description" rows="5"
                                 maxLength="500" pTooltip="Description has a 500 character limit."></textarea>
                         </label>
-                    </div>
-                    <div class="margin-top-md">
-                        <p-checkbox [(ngModel)]="autoUpdate" label="Auto Update" binary="true"></p-checkbox>
-                        <div class="help-block">
-                            Controls whether recipes containing this type will be automatically updated.
-                        </div>
-                    </div>
+                    </div>                   
                 </div>
             </div>
             <div class="p-grid">

--- a/projects/developer/src/app/configuration/recipe-types/component.ts
+++ b/projects/developer/src/app/configuration/recipe-types/component.ts
@@ -481,7 +481,6 @@ export class RecipeTypesComponent implements OnInit, OnDestroy {
                 this.messageService.add({ severity: 'error', summary: 'Error creating recipe type', detail: err.statusText });
             });
         } else {
-            cleanRecipeType.auto_update = true; //should always auto update
             this.recipeTypesApiService.editRecipeType(this.selectedRecipeTypeDetail.name, cleanRecipeType).subscribe(() => {
                 this.isEditing = false;
                 this.showAddRemoveDisplay = false;

--- a/projects/developer/src/app/configuration/recipe-types/component.ts
+++ b/projects/developer/src/app/configuration/recipe-types/component.ts
@@ -61,7 +61,6 @@ export class RecipeTypesComponent implements OnInit, OnDestroy {
     conditionColumns: any[];
     showAddRemoveDisplay: boolean;
     addRemoveDisplayType = 'job';
-    autoUpdate = false;
     menuBarItems: MenuItem[] = [
         { label: 'Job Type Nodes', icon: 'fa fa-cube',
             command: () => {
@@ -482,7 +481,7 @@ export class RecipeTypesComponent implements OnInit, OnDestroy {
                 this.messageService.add({ severity: 'error', summary: 'Error creating recipe type', detail: err.statusText });
             });
         } else {
-            cleanRecipeType.auto_update = this.autoUpdate;
+            cleanRecipeType.auto_update = true; //should always auto update
             this.recipeTypesApiService.editRecipeType(this.selectedRecipeTypeDetail.name, cleanRecipeType).subscribe(() => {
                 this.isEditing = false;
                 this.showAddRemoveDisplay = false;


### PR DESCRIPTION
remove auto complete toggle in the UI.  Auto complete is a default and not something that the user needs to select.  Removed from the payload to send to the API as well.