### PR TITLE
Issue 387 - Simplify auth path, expose redirect timeout as config, fix ?next= param

### DIFF
--- a/projects/developer/src/app/app.component.ts
+++ b/projects/developer/src/app/app.component.ts
@@ -61,12 +61,7 @@ export class AppComponent implements OnInit {
                     this.isAuthenticated = true;
                 } else {
                     // attempt to authenticate
-                    if (environment.authSchemeType === 'geoaxis') {
-                        // redirect to geoaxis login
-                        this.header = 'Authentication is Required';
-                        this.message = 'Redirecting to GEOAxIS...';
-                        window.location.href = `${environment.authSchemeUrl}http://127.0.0.1:8080`;
-                    } else if (environment.authSchemeType === 'form') {
+                    if (environment.authSchemeType === 'form') {
                         // show login form
                         this.header = 'Authentication is Required';
                         this.message = 'Enter your username and password to continue.';
@@ -74,20 +69,16 @@ export class AppComponent implements OnInit {
                     } else {
                         // redirect
                         this.header = 'Authentication is Required';
-                        this.message = 'Redirecting to login form...';
+                        this.message = 'Redirecting...';
                         setTimeout(() => {
                             window.location.href = `${environment.authSchemeUrl}?next=${window.location.href}`;
-                        }, 3000);
+                        }, environment.authRedirectTimeout);
                     }
                 }
             }, err => {
                 this.loading = false;
                 console.log(err);
-                if (environment.authSchemeType === 'geoaxis') {
-                    this.header = 'Authentication is Required';
-                    this.message = 'Redirecting to GEOAxIS...';
-                    window.location.href = `${environment.authSchemeUrl}${window.location.href}`;
-                } else if (environment.authSchemeType === 'form') {
+                if (environment.authSchemeType === 'form') {
                     // GET call to retrieve CSRF cookie
                     this.profileService.getLogin().subscribe(data => {
                         console.log(data);
@@ -105,10 +96,10 @@ export class AppComponent implements OnInit {
                 } else {
                     // redirect
                     this.header = 'Authentication is Required';
-                    this.message = 'Redirecting to login form...';
+                    this.message = 'Redirecting...';
                     setTimeout(() => {
                         window.location.href = `${environment.authSchemeUrl}?next=${window.location.href}`;
-                    }, 3000);
+                    }, environment.authRedirectTimeout);
                 }
             });
         } else {

--- a/projects/developer/src/environments/environment.prod.ts
+++ b/projects/developer/src/environments/environment.prod.ts
@@ -9,6 +9,7 @@ export const environment = {
     authEnabled: false,
     authSchemeType: '',
     authSchemeUrl: '',
+    authRedirectTimeout: 0,
     dateFormat: '',
     defaultTheme: '',
     documentation: '',

--- a/projects/developer/src/environments/environment.ts
+++ b/projects/developer/src/environments/environment.ts
@@ -13,6 +13,7 @@ export const environment = {
     authEnabled: false,
     authSchemeType: '',
     authSchemeUrl: '',
+    authRedirectTimeout: 0,
     dateFormat: '',
     defaultTheme: '',
     documentation: '',


### PR DESCRIPTION
Closes #387 

- GeoAXIS was missing the `?next=` param in the URL config
- GeoAXIS had a hardcoded localhost redirect
- Same code for non-form and GeoAXIS path, simplify down to just the special cases for form type
- Expose redirect timeout as config variable, set to 0 by default