### PR TITLE
Issue 391 - Allow using temporal filter in live range mode only

### DIFF
--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -1,25 +1,27 @@
-<div class="temporal-filter flexed">
-    <div class="ui-inputgroup">
-        <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
-        <p-calendar [(ngModel)]="startDate" inputId="date-range-start" showButtonBar="true"
-                    panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
-                    dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
-                    showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
-    </div>
+<div class="temporal-filter flexed" [ngClass]="{'spaced': !liveRangeOnly}">
+    <ng-container *ngIf="!liveRangeOnly">
+        <div class="ui-inputgroup">
+            <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
+            <p-calendar [(ngModel)]="startDate" inputId="date-range-start" showButtonBar="true"
+                        panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
+                        dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
+                        showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+        </div>
 
-    <div class="ui-inputgroup">
-        <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
-        <p-calendar [(ngModel)]="endDate" inputId="date-range-end" showButtonBar="true"
-                    panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
-                    dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
-                    showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
-    </div>
+        <div class="ui-inputgroup">
+            <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
+            <p-calendar [(ngModel)]="endDate" inputId="date-range-end" showButtonBar="true"
+                        panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
+                        dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
+                        showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+        </div>
 
-    <button pButton class="temporal-filter__date-filter-btn apply-"
-            [ngClass]="{'ui-button-primary': !isLiveMode, 'ui-button-secondary': isLiveMode}" label="Apply filter"
-            (click)="onDateFilterApply()"
-            [disabled]="!startDate || !endDate || !isValid"
-            pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
+        <button pButton class="temporal-filter__date-filter-btn apply-"
+                [ngClass]="{'ui-button-primary': !isLiveMode, 'ui-button-secondary': isLiveMode}" label="Apply filter"
+                (click)="onDateFilterApply()"
+                [disabled]="!startDate || !endDate || !isValid"
+                pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
+    </ng-container>
 
     <div class="temporal-filter__date-filter-dropdown">
         <div class="ui-inputgroup">
@@ -32,7 +34,7 @@
             <p-dropdown [options]="dateRangeOptions" [(ngModel)]="liveRange"
                         (onChange)="onLiveRangeChange()"
                         inputId="date-range-live"
-                        [showClear]="true">
+                        [showClear]="!liveRangeOnly">
             </p-dropdown>
         </div>
     </div>

--- a/projects/developer/src/app/common/components/temporal-filter/component.scss
+++ b/projects/developer/src/app/common/components/temporal-filter/component.scss
@@ -29,11 +29,13 @@
         padding-bottom: 0;
     }
 
-    .temporal-filter__date-filter-ranges, .temporal-filter__date-filter-dropdown {
-        margin-left: 55px;
+    &.spaced {
+        .temporal-filter__date-filter-ranges, .temporal-filter__date-filter-dropdown {
+            margin-left: 55px;
 
-        button {
-            margin-left: 3px;
+            button {
+                margin-left: 3px;
+            }
         }
     }
     .share_btn{

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -16,6 +16,8 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
     @Input() ended: string;
     @Input() liveRange: number;
     @Input() loading = false;
+    @Input() localStorageKey = 'temporal-filter';
+    @Input() liveRangeOnly = false;
 
     // when the start/end dates are applied
     @Output() dateFilterSelected: EventEmitter<{start: string, end: string}> = new EventEmitter();
@@ -71,13 +73,13 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
     get isLiveMode(): boolean { return !!this.liveRange; }
 
     // used for saving started value into local storage
-    private startedStorage = new LocalStorageItem('started', 'temporal-filter');
+    private startedStorage: LocalStorageItem;
 
     // used for saving ended value into local storage
-    private endedStorage = new LocalStorageItem('ended', 'temporal-filter');
+    private endedStorage: LocalStorageItem;
 
     // used for saving live range value into local storage
-    private liveRangeStorage = new LocalStorageItem('range', 'temporal-filter');
+    private liveRangeStorage: LocalStorageItem;
 
     // determines if the form inputs are valid
     get isValid(): boolean {
@@ -214,34 +216,50 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
+        // initialize storage with passed in @Input keys
+        this.startedStorage = new LocalStorageItem('started', this.localStorageKey);
+        this.endedStorage = new LocalStorageItem('ended', this.localStorageKey);
+        this.liveRangeStorage = new LocalStorageItem('range', this.localStorageKey);
+
+        // restrict options for in live range only mode
+        if (this.liveRangeOnly) {
+            this.dateRangeOptions = this.dateRangeOptions.filter(d => d.value);
+        }
+
         // prevent expression changed error
         setTimeout(() => {
             if (this.liveRange) {
                 // live range was set from parent (router)
                 this.liveRangeStorage.set(this.liveRange);
                 this.onLiveRangeChange();
-            } else if (this.started && this.ended) {
+            } else if (!this.liveRangeOnly && this.started && this.ended) {
                 // start/end dates were set from parent (router)
                 this.startDate = this.utcDateToLocal(this.started);
                 this.endDate = this.utcDateToLocal(this.ended);
                 this.onDateFilterApply();
-            } else if (this.liveRangeStorage) {
+            } else if (this.liveRangeStorage.get()) {
                 // live range and start/end not provided by parent
                 // live range available in localstorage
                 this.liveRange = this.liveRangeStorage.get();
                 this.onLiveRangeChange();
-            } else if (this.startedStorage && this.endedStorage) {
+            } else if (this.startedStorage.get() && this.endedStorage.get()) {
                 // start/end provided from localstorage
                 this.startDate = this.utcDateToLocal(this.startedStorage.get());
                 this.endDate = this.utcDateToLocal(this.endedStorage.get());
                 this.onDateFilterApply();
             } else {
-                // nothing provided by parent component or found in storage
-                // use date filter on the last day
-                const now = moment();
-                this.endDate = now.toDate();
-                this.startDate = now.clone().subtract(1, 'day').toDate();
-                this.onDateFilterApply();
+                if (this.liveRangeOnly) {
+                    // force using the live range value, provide a default
+                    this.liveRange = this.dateRangeOptions[0].value;
+                    this.onLiveRangeChange();
+                } else {
+                    // nothing provided by parent component or found in storage
+                    // use date filter on the last day
+                    const now = moment();
+                    this.endDate = now.toDate();
+                    this.startDate = now.clone().subtract(1, 'day').toDate();
+                    this.onDateFilterApply();
+                }
             }
         });
     }


### PR DESCRIPTION
This should allow using the temporal filter in "live range" mode only.

Template usage:
```html
<dev-temporal-filter
                     localStorageKey="dashboard-filter"
                     [liveRangeOnly]="true"
                     (updated)="onTemporalFilterUpdate($event)">
</dev-temporal-filter>
```

In your component:
```ts
onTemporalFilterUpdate(data: {start: string, end: string}): void {
    // this will be fired every 10 seconds with a start/end datetime
}
```