### PR TITLE
Issues 400 and 401 - Ensure condition interface is consistent and not lost during edit

### DIFF
--- a/projects/developer/src/app/common/components/recipe-graph/component.ts
+++ b/projects/developer/src/app/common/components/recipe-graph/component.ts
@@ -10,6 +10,8 @@ import { BatchesApiService } from '../../../processing/batches/api.service';
 import { Batch } from '../../../processing/batches/api.model';
 import { BatchesDatatable } from '../../../processing/batches/datatable.model';
 import { MessageService } from 'primeng/components/common/messageservice';
+import { RecipeTypeInputFile } from '../../../configuration/recipe-types/api.input.file.model';
+import { RecipeTypeInputJson } from '../../../configuration/recipe-types/api.input.json.model';
 
 @Component({
     selector: 'dev-recipe-graph',
@@ -310,9 +312,9 @@ export class RecipeGraphComponent implements OnInit, OnChanges, AfterViewInit {
             let inputFile;
             _.forEach(fileTypes, (file, key) => {
                 if (file.output === i.output) {
-                inputFile = key;
-                let connection;
-                    if (i.node) {
+                    inputFile = key;
+                    let connection;
+                        if (i.node) {
                             const dependency = this.recipeData.definition.nodes[i.node];
                             if (dependency) {
                                 connection = _.find(this.recipeData.definition.input.files, {name: i.node});
@@ -603,12 +605,12 @@ export class RecipeGraphComponent implements OnInit, OnChanges, AfterViewInit {
                 });
                 // update interface in recipeData and selectedCondition
                 this.recipeData.definition.nodes[this.selectedNode.node_type.name].node_type.interface = {
-                    files: files,
-                    json: json
+                    files: RecipeTypeInputFile.transformer(files),
+                    json: RecipeTypeInputJson.transformer(json)
                 };
                 this.selectedCondition.interface = {
-                    files: files,
-                    json: json
+                    files: RecipeTypeInputFile.transformer(files),
+                    json: RecipeTypeInputJson.transformer(json)
                 };
                 // update input in recipeData and selectedNode
                 this.recipeData.definition.nodes[this.selectedNode.node_type.name].input = input;

--- a/projects/developer/src/app/configuration/recipe-types/component.ts
+++ b/projects/developer/src/app/configuration/recipe-types/component.ts
@@ -536,7 +536,7 @@ export class RecipeTypesComponent implements OnInit, OnDestroy {
 
             // update condition node in recipe details
             // same idea as RecipeType.addCondition(), but update it here as well
-            const cidx = _.findIndex(this.selectedRecipeTypeDetail.conditions);
+            const cidx = _.findIndex(this.selectedRecipeTypeDetail.conditions, {name: event.condition.name});
             this.selectedRecipeTypeDetail.conditions[cidx] = event.condition;
         } else {
             this.conditions.push(event.condition);

--- a/projects/developer/src/app/configuration/recipe-types/condition.component.ts
+++ b/projects/developer/src/app/configuration/recipe-types/condition.component.ts
@@ -16,7 +16,7 @@ export class RecipeTypeConditionComponent implements OnInit, OnDestroy {
     @Input() conditions: RecipeTypeCondition[];
     @Output() save: EventEmitter<any> = new EventEmitter<any>();
     @Output() cancel: EventEmitter<any> = new EventEmitter<any>();
-    private condition = RecipeTypeCondition.transformer(this.editCondition);
+    private condition: RecipeTypeCondition;
     private oldCondition: RecipeTypeCondition;
     private subscriptions: Subscription[] = [];
 
@@ -119,6 +119,9 @@ export class RecipeTypeConditionComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
+        // create initial copy of editing condition passed in, data will be merged into this copy
+        this.condition = RecipeTypeCondition.transformer(this.editCondition) as RecipeTypeCondition;
+
         // create a copy of the passed in edit condition, if any
         // will create an empty condition if given null value
         this.oldCondition = RecipeTypeCondition.transformer(this.editCondition) as RecipeTypeCondition;


### PR DESCRIPTION
Closes #400 and closes #401, hopefully. This will need to be thoroughly tested.

The interface of condition nodes gets changed when adding it as a dependency to another node. This needs to be processed by the model, mainly to ensure the `multiple` is a boolean (happens in the constructor of the model). I think this fixes #401.

Related, if you resaved that condition node, validation would pass after that, as outlined in #401, since it was stripping out the interface block during edit. By properly copying the interface when editing, it should stick around now, fixing #400.