### PR TITLE
Issue 441 - Editing a New Recipe Type

### DIFF
--- a/projects/developer/src/app/configuration/recipe-types/component.ts
+++ b/projects/developer/src/app/configuration/recipe-types/component.ts
@@ -502,6 +502,7 @@ export class RecipeTypesComponent implements OnInit, OnDestroy {
                 this.showJsonInputs = false;
                 this.showConditions = false;
                 this.selectedRecipeTypeDetail = RecipeType.transformer(result);
+                this.recipeTypeName = this.selectedRecipeTypeDetail.name;
                 this.messageService.add({ severity: 'success', summary: 'Success', detail: `${result.title} successfully created` });
                 // modify url without reloading view
                 window.history.pushState({}, '', `/configuration/recipe-types/${result.name}`);


### PR DESCRIPTION
* Sets recipeTypeName in the component to the name returned from the recipeType service createRecipeType function call. This was causing the component to consider the newly created recipe to not have a name and therefore route back to the recipe-types list.