### PR TITLE
Issue 445 - simplify date time and live range pickers

### DIFF
--- a/projects/developer/src/app/app.module.ts
+++ b/projects/developer/src/app/app.module.ts
@@ -105,6 +105,7 @@ import { StatusComponent } from './navbar/status/component';
 import { StrikesComponent } from './system/strikes/component';
 import { SubnavComponent } from './navbar/subnav/subnav.component';
 import { SystemStatusComponent } from './system/status/component';
+import { LiveRangeSelectorComponent } from './common/components/live-range-selector/component';
 import { TemporalFilterComponent } from './common/components/temporal-filter/component';
 import { ThemeModule, lightTheme, darkTheme } from './theme';
 import { TimelineComponent } from './data/timeline/component';
@@ -173,6 +174,7 @@ const appInitializer = (appConfig: AppConfigService) => {
         SystemStatusComponent,
         TimelineComponent,
         WorkspacesComponent,
+        LiveRangeSelectorComponent,
         TemporalFilterComponent,
         BatchWorkflowComponent,
         CreateDatasetComponent,

--- a/projects/developer/src/app/common/components/live-range-selector/component.html
+++ b/projects/developer/src/app/common/components/live-range-selector/component.html
@@ -4,13 +4,12 @@
             <label class="ui-inputgroup-addon" for="date-range-live">
                 <i class="fa live-range-icon"
                    [ngClass]="liveRangeIconClass"
-                   [pTooltip]="isLiveMode ? 'Refreshing every 10 seconds' : 'No live filter applied'" tooltipPosition="bottom"></i>
+                   pTooltip="Refreshing every 10 seconds" tooltipPosition="bottom"></i>
                 Live range
             </label>
             <p-dropdown [options]="dateRangeOptions" [(ngModel)]="liveRange"
                         (onChange)="onLiveRangeChange()"
-                        inputId="date-range-live"
-                        [showClear]="!liveRangeOnly">
+                        inputId="date-range-live">
             </p-dropdown>
         </div>
     </div>

--- a/projects/developer/src/app/common/components/live-range-selector/component.html
+++ b/projects/developer/src/app/common/components/live-range-selector/component.html
@@ -1,0 +1,17 @@
+<div class="live-range-selector flexed">
+    <div class="live-range-selector__date-filter-dropdown">
+        <div class="ui-inputgroup">
+            <label class="ui-inputgroup-addon" for="date-range-live">
+                <i class="fa live-range-icon"
+                   [ngClass]="liveRangeIconClass"
+                   [pTooltip]="isLiveMode ? 'Refreshing every 10 seconds' : 'No live filter applied'" tooltipPosition="bottom"></i>
+                Live range
+            </label>
+            <p-dropdown [options]="dateRangeOptions" [(ngModel)]="liveRange"
+                        (onChange)="onLiveRangeChange()"
+                        inputId="date-range-live"
+                        [showClear]="!liveRangeOnly">
+            </p-dropdown>
+        </div>
+    </div>
+</div>

--- a/projects/developer/src/app/common/components/live-range-selector/component.scss
+++ b/projects/developer/src/app/common/components/live-range-selector/component.scss
@@ -1,0 +1,77 @@
+.live-range-selector {
+    align-items: flex-end;
+
+    div {
+        margin-right: 20px;
+    }
+
+    .ui-inputgroup {
+        .ui-inputgroup-addon {
+            line-height:  normal;
+        }
+
+        ::ng-deep input,
+        ::ng-deep .ui-dropdown {
+            line-height:  normal;
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            flex: 1 1 auto;
+        }
+    }
+
+    .live-range-selector__date-filter-btn, .live-range-selector__date-filter-dropdown {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
+    &.spaced {
+        .live-range-selector__date-filter-ranges, .live-range-selector__date-filter-dropdown {
+            margin-left: 55px;
+
+            button {
+                margin-left: 3px;
+            }
+        }
+    }
+
+    .live-range-icon {
+        margin-left: 5px;
+        margin-right: 5px;
+    }
+
+    .live-range-inactive {
+        color:grey
+    }
+
+    .live-range-active {
+        animation:greenBlinking 1.5s infinite;
+    }
+
+    .live-range-error {
+        animation:redBlinking 1.5s infinite;
+    }
+}
+
+@media screen and (max-width: 858px) {
+    .live-range-selector__date-filter-btn, .live-range-selector__date-filter-dropdown, .live-range-selector__date-filter-ranges {
+        margin-left: 0 !important;
+        padding: 0 !important;
+    }
+
+    .live-range-selector__date-filter-dropdown, .live-range-selector__date-filter-btn {
+        margin-top: 5px !important;
+        margin-right: 5px !important;
+    }
+}
+
+@keyframes redBlinking{
+    0%{     color: #777;    }
+    50%{    color: var(--red); }
+    100%{   color: #777;    }
+}
+
+@keyframes greenBlinking{
+    0%{     color: #777;    }
+    50%{    color: var(--green); }
+    100%{   color: #777;    }
+}

--- a/projects/developer/src/app/common/components/live-range-selector/component.scss
+++ b/projects/developer/src/app/common/components/live-range-selector/component.scss
@@ -42,10 +42,6 @@
     .live-range-active {
         animation:greenBlinking 1.5s infinite;
     }
-
-    .live-range-error {
-        animation:redBlinking 1.5s infinite;
-    }
 }
 
 @media screen and (max-width: 858px) {
@@ -58,12 +54,6 @@
         margin-top: 5px !important;
         margin-right: 5px !important;
     }
-}
-
-@keyframes redBlinking{
-    0%{     color: #777;    }
-    50%{    color: var(--red); }
-    100%{   color: #777;    }
 }
 
 @keyframes greenBlinking{

--- a/projects/developer/src/app/common/components/live-range-selector/component.scss
+++ b/projects/developer/src/app/common/components/live-range-selector/component.scss
@@ -40,7 +40,7 @@
     }
 
     .live-range-active {
-        animation:greenBlinking 1.5s infinite;
+        animation:greenBlinking 0.75s alternate ease-in-out infinite;
     }
 }
 
@@ -57,7 +57,6 @@
 }
 
 @keyframes greenBlinking{
-    0%{     color: #777;    }
-    50%{    color: var(--green); }
-    100%{   color: #777;    }
+    from { color: #777; }
+    to {   color: var(--green); }
 }

--- a/projects/developer/src/app/common/components/live-range-selector/component.scss
+++ b/projects/developer/src/app/common/components/live-range-selector/component.scss
@@ -39,10 +39,6 @@
         margin-right: 5px;
     }
 
-    .live-range-inactive {
-        color:grey
-    }
-
     .live-range-active {
         animation:greenBlinking 1.5s infinite;
     }

--- a/projects/developer/src/app/common/components/live-range-selector/component.spec.ts
+++ b/projects/developer/src/app/common/components/live-range-selector/component.spec.ts
@@ -1,0 +1,31 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/components/common/messageservice';
+
+import { TemporalFilterComponent } from './component';
+
+describe('TemporalFilterComponent', () => {
+    let component: TemporalFilterComponent;
+    let fixture: ComponentFixture<TemporalFilterComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [TemporalFilterComponent],
+            imports: [],
+            providers: [MessageService],
+            // Tells the compiler not to error on unknown elements and attributes
+            schemas: [NO_ERRORS_SCHEMA]
+        })
+            .compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TemporalFilterComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should be created', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/projects/developer/src/app/common/components/live-range-selector/component.ts
+++ b/projects/developer/src/app/common/components/live-range-selector/component.ts
@@ -1,0 +1,139 @@
+import { Component, EventEmitter, Input, OnInit, OnDestroy, Output } from '@angular/core';
+import { Subscription, Observable } from 'rxjs';
+import 'rxjs/add/observable/timer';
+import * as moment from 'moment';
+
+import { LocalStorageItem } from '../../utils/localstorage';
+
+@Component({
+    selector: 'dev-live-range-selector',
+    templateUrl: './component.html',
+    styleUrls: ['./component.scss']
+})
+export class LiveRangeSelectorComponent implements OnInit, OnDestroy {
+    @Input() liveRange: number;
+    @Input() loading = false;
+    @Input() localStorageKey = 'temporal-filter';
+    @Input() refreshRate = 10;
+
+    // dropdown options for live range, values in hourss
+    @Input() dateRangeOptions = [
+        { label: '---', value: null },
+        { label: 'Last 1 hour', value: 1 },
+        { label: 'Last 6 hours', value: 6 },
+        { label: 'Last 12 hours', value: 12 },
+        { label: 'Last day', value: 24 },
+        { label: 'Last 3 days', value: 24 * 3 },
+        { label: 'Last week', value: 24 * 7 }
+    ];
+
+    // when the live range dropdown value is selected or cleared
+    @Output() liveRangeSelected: EventEmitter<{hours: number}> = new EventEmitter();
+    // when the parent component should make an api call to update the data
+    // driven by the timer for the live range update, as well as normal start/end date filter apply
+    @Output() updated: EventEmitter<{start: string, end: string}> = new EventEmitter();
+
+    selectedDateRange: any;
+
+    // timer subscription, firing when a live range should be changed
+    private liveRangeSubscription: Subscription;
+
+    // year range to show in the calendar dropdown
+    get yearRange(): string {
+        const now = moment();
+        const start = now.clone().subtract(20, 'y').year();
+        const end = now.clone().add(5, 'y').year();
+        return `${start}:${end}`;
+    }
+
+    // dynamic css class to use for live range icon
+    get liveRangeIconClass(): string {
+        if (this.loading) {
+            return 'fa-circle-o-notch fa-spin';
+        } else {
+            return 'fa-circle live-range-active';
+        }
+    }
+
+    // used for saving live range value into local storage
+    private liveRangeStorage: LocalStorageItem;
+
+    constructor(
+    ) {
+    }
+
+
+    private unsubscribe(): void {
+        if (this.liveRangeSubscription) {
+            this.liveRangeSubscription.unsubscribe();
+            this.liveRangeSubscription = null;
+        }
+    }
+
+    /**
+     * Update hook to emit out the start/end dates the parent component should filter on.
+     * @param now optional param for now for live range, otherwise will use start/end
+     */
+    private update(now: moment.Moment): void {
+        this.updated.emit({
+            start: now.clone().subtract(this.liveRange, 'h').toISOString(),
+            end: now.toISOString()
+        });
+    }
+
+    /**
+     * Callback for when the live range model changes to either emit the value or reset the filter range.
+     */
+    onLiveRangeChange(): void {
+        if (this.liveRange) {
+
+            // emit out the live range selection
+            this.liveRangeSelected.emit({ hours: this.liveRange });
+
+            // save to local storage
+            this.liveRangeStorage.set(this.liveRange);
+
+            // ensure any timers are cancelled, then start a new one
+            this.unsubscribe();
+            this.liveRangeSubscription = Observable.timer(0, this.refreshRate * 1000)
+                .subscribe(() => {
+                    // update using now for the base
+                    this.update(moment.utc());
+                });
+        } else {
+            // live range was cleared, make sure timers are cleared
+            this.unsubscribe();
+        }
+    }
+
+    ngOnInit() {
+        // initialize storage with passed in @Input keys
+        this.liveRangeStorage = new LocalStorageItem('range', this.localStorageKey);
+
+        // restrict options for in live range only mode
+        this.dateRangeOptions = this.dateRangeOptions.filter(d => d.value);
+
+        // prevent expression changed error
+        setTimeout(() => {
+            if (this.liveRange) {
+                // live range was set from parent (router)
+                this.liveRangeStorage.set(this.liveRange);
+                this.onLiveRangeChange();
+            } else if (this.liveRangeStorage.get()) {
+                // live range and start/end not provided by parent
+                // live range available in localstorage
+                this.liveRange = this.liveRangeStorage.get();
+                this.onLiveRangeChange();
+            } else {
+                // force using the live range value, provide a default
+                this.liveRange = this.dateRangeOptions[0].value;
+                this.onLiveRangeChange();
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        this.unsubscribe();
+    }
+
+}

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -2,6 +2,7 @@
     <div class="ui-inputgroup">
         <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
         <p-calendar [(ngModel)]="startDate"
+                    (ngModelChange)="onStartChange($event)"
                     [defaultDate]="defaultDate"
                     inputId="date-range-start"
                     showButtonBar="true"
@@ -20,6 +21,7 @@
     <div class="ui-inputgroup">
         <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
         <p-calendar [(ngModel)]="endDate"
+                    (ngModelChange)="onEndChange($event)"
                     [defaultDate]="defaultDate"
                     inputId="date-range-end"
                     showButtonBar="true"

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -5,6 +5,7 @@
                     panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
                     dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
                     showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+        <span class="ui-inputgroup-addon">Z</span>
     </div>
 
     <div class="ui-inputgroup">
@@ -13,6 +14,7 @@
                     panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
                     dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
                     showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+        <span class="ui-inputgroup-addon">Z</span>
     </div>
 
     <button pButton class="temporal-filter__date-filter-btn ui-button-primary"

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -1,19 +1,37 @@
 <div class="temporal-filter flexed spaced">
     <div class="ui-inputgroup">
         <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
-        <p-calendar [(ngModel)]="startDate" inputId="date-range-start" showButtonBar="true"
-                    panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
-                    dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
-                    showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+        <p-calendar [(ngModel)]="startDate"
+                    [defaultDate]="defaultDate"
+                    inputId="date-range-start"
+                    showButtonBar="true"
+                    panelStyleClass="temporalDateFilter"
+                    [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
+                    dateFormat="yy/mm/dd"
+                    [monthNavigator]="true"
+                    [yearNavigator]="true"
+                    [yearRange]="yearRange"
+                    showTime="true"
+                    hourFormat="24"
+                    [showSeconds]="true"></p-calendar>
         <span class="ui-inputgroup-addon">Z</span>
     </div>
 
     <div class="ui-inputgroup">
         <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
-        <p-calendar [(ngModel)]="endDate" inputId="date-range-end" showButtonBar="true"
-                    panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
-                    dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
-                    showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+        <p-calendar [(ngModel)]="endDate"
+                    [defaultDate]="defaultDate"
+                    inputId="date-range-end"
+                    showButtonBar="true"
+                    panelStyleClass="temporalDateFilter"
+                    [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
+                    dateFormat="yy/mm/dd"
+                    [monthNavigator]="true"
+                    [yearNavigator]="true"
+                    [yearRange]="yearRange"
+                    showTime="true"
+                    hourFormat="24"
+                    [showSeconds]="true"></p-calendar>
         <span class="ui-inputgroup-addon">Z</span>
     </div>
 

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -1,5 +1,5 @@
 <div class="temporal-filter flexed spaced">
-    <div class="ui-inputgroup">
+    <div class="ui-inputgroup" [ngClass]="{'highlight': showHighlight}">
         <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
         <p-calendar [(ngModel)]="startDate"
                     (ngModelChange)="onStartChange($event)"
@@ -18,7 +18,7 @@
         <span class="ui-inputgroup-addon">Z</span>
     </div>
 
-    <div class="ui-inputgroup">
+    <div class="ui-inputgroup" [ngClass]="{'highlight': showHighlight}">
         <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
         <p-calendar [(ngModel)]="endDate"
                     (ngModelChange)="onEndChange($event)"
@@ -38,18 +38,18 @@
     </div>
 
     <div class="ui-inputgroup">
-        <p-menu #dateRangeMenu [popup]="true" [model]="dateRangeOptions"></p-menu>
-
         <button type="button"
                 pButton
-                icon="fa fa-calendar"
+                *ngFor="let dateRangeOption of dateRangeOptions"
+                [label]="dateRangeOption.label"
                 class="ui-button-secondary"
-                (click)="dateRangeMenu.toggle($event)"></button>
-
-        <button pButton class="temporal-filter__date-filter-btn ui-button-primary"
-                icon="fa fa-refresh"
-                (click)="onDateFilterApply()"
-                [disabled]="!isValid || loading"
-                pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
+                [disabled]="loading"
+                (click)="selectRange(dateRangeOption.value)"></button>
     </div>
+
+    <button pButton class="temporal-filter__date-filter-btn ui-button-primary"
+            icon="fa fa-refresh"
+            (click)="onDateFilterApply()"
+            [disabled]="!isValid || loading"
+            pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
 </div>

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -37,7 +37,9 @@
         <span class="ui-inputgroup-addon">Z</span>
     </div>
 
-    <div class="ui-inputgroup">
+    <div class="ui-inputgroup"
+         pTooltip="Apply date range" showDelay="300" tooltipPosition="bottom"
+    >
         <button type="button"
                 pButton
                 *ngFor="let dateRangeOption of dateRangeOptions"
@@ -51,5 +53,5 @@
             icon="fa fa-refresh"
             (click)="onDateFilterApply()"
             [disabled]="!isValid || loading"
-            pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
+            pTooltip="Reload with selected filters" showDelay="300" tooltipPosition="bottom"></button>
 </div>

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -17,9 +17,19 @@
         <span class="ui-inputgroup-addon">Z</span>
     </div>
 
-    <button pButton class="temporal-filter__date-filter-btn ui-button-primary"
-            label="Apply"
-            (click)="onDateFilterApply()"
-            [disabled]="!isValid || loading"
-            pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
+    <div class="ui-inputgroup">
+        <p-menu #dateRangeMenu [popup]="true" [model]="dateRangeOptions"></p-menu>
+
+        <button type="button"
+                pButton
+                icon="fa fa-calendar"
+                class="ui-button-secondary"
+                (click)="dateRangeMenu.toggle($event)"></button>
+
+        <button pButton class="temporal-filter__date-filter-btn ui-button-primary"
+                icon="fa fa-refresh"
+                (click)="onDateFilterApply()"
+                [disabled]="!isValid || loading"
+                pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
+    </div>
 </div>

--- a/projects/developer/src/app/common/components/temporal-filter/component.html
+++ b/projects/developer/src/app/common/components/temporal-filter/component.html
@@ -1,41 +1,23 @@
-<div class="temporal-filter flexed" [ngClass]="{'spaced': !liveRangeOnly}">
-    <ng-container *ngIf="!liveRangeOnly">
-        <div class="ui-inputgroup">
-            <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
-            <p-calendar [(ngModel)]="startDate" inputId="date-range-start" showButtonBar="true"
-                        panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
-                        dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
-                        showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
-        </div>
-
-        <div class="ui-inputgroup">
-            <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
-            <p-calendar [(ngModel)]="endDate" inputId="date-range-end" showButtonBar="true"
-                        panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
-                        dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
-                        showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
-        </div>
-
-        <button pButton class="temporal-filter__date-filter-btn apply-"
-                [ngClass]="{'ui-button-primary': !isLiveMode, 'ui-button-secondary': isLiveMode}" label="Apply filter"
-                (click)="onDateFilterApply()"
-                [disabled]="!startDate || !endDate || !isValid"
-                pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
-    </ng-container>
-
-    <div class="temporal-filter__date-filter-dropdown">
-        <div class="ui-inputgroup">
-            <label class="ui-inputgroup-addon" for="date-range-live">
-                <i class="fa live-range-icon"
-                   [ngClass]="liveRangeIconClass"
-                   [pTooltip]="isLiveMode ? 'Refreshing every 10 seconds' : 'No live filter applied'" tooltipPosition="bottom"></i>
-                Live range
-            </label>
-            <p-dropdown [options]="dateRangeOptions" [(ngModel)]="liveRange"
-                        (onChange)="onLiveRangeChange()"
-                        inputId="date-range-live"
-                        [showClear]="!liveRangeOnly">
-            </p-dropdown>
-        </div>
+<div class="temporal-filter flexed spaced">
+    <div class="ui-inputgroup">
+        <label class="ui-inputgroup-addon" for="date-range-start">Start</label>
+        <p-calendar [(ngModel)]="startDate" inputId="date-range-start" showButtonBar="true"
+                    panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
+                    dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
+                    showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
     </div>
+
+    <div class="ui-inputgroup">
+        <label class="ui-inputgroup-addon" for="date-range-end">Stop</label>
+        <p-calendar [(ngModel)]="endDate" inputId="date-range-end" showButtonBar="true"
+                    panelStyleClass="temporalDateFilter" [inputStyleClass]="isValid ? '' : 'ng-dirty ng-invalid'"
+                    dateFormat="yy/mm/dd" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="yearRange"
+                    showTime="true" hourFormat="24" [showSeconds]="true"></p-calendar>
+    </div>
+
+    <button pButton class="temporal-filter__date-filter-btn ui-button-primary"
+            label="Apply"
+            (click)="onDateFilterApply()"
+            [disabled]="!isValid || loading"
+            pTooltip="Start date must be before end date" [tooltipDisabled]="isValid"></button>
 </div>

--- a/projects/developer/src/app/common/components/temporal-filter/component.scss
+++ b/projects/developer/src/app/common/components/temporal-filter/component.scss
@@ -27,6 +27,10 @@
             border-radius: 0;
             flex: 1 1 auto;
         }
+
+        > button:not(:last-child) {
+            border-right: 1px solid var(--navbar-light) !important;
+        }
     }
 
     .temporal-filter__date-filter-btn, .temporal-filter__date-filter-dropdown {

--- a/projects/developer/src/app/common/components/temporal-filter/component.scss
+++ b/projects/developer/src/app/common/components/temporal-filter/component.scss
@@ -18,8 +18,7 @@
         ::ng-deep input,
         ::ng-deep .ui-dropdown {
             line-height:  normal;
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
+            border-radius: 0;
             flex: 1 1 auto;
         }
     }

--- a/projects/developer/src/app/common/components/temporal-filter/component.scss
+++ b/projects/developer/src/app/common/components/temporal-filter/component.scss
@@ -11,6 +11,12 @@
     }
 
     .ui-inputgroup {
+        transition: box-shadow ease-in-out 200ms;
+
+        &.highlight {
+            box-shadow: 0 0 5px var(--scale-primary);
+        }
+
         .ui-inputgroup-addon {
             line-height:  normal;
         }

--- a/projects/developer/src/app/common/components/temporal-filter/component.scss
+++ b/projects/developer/src/app/common/components/temporal-filter/component.scss
@@ -38,26 +38,6 @@
             }
         }
     }
-    .share_btn{
-        margin-left: 10px;
-    }
-
-    .live-range-icon {
-        margin-left: 5px;
-        margin-right: 5px;
-    }
-
-    .live-range-inactive {
-        color:grey
-    }
-
-    .live-range-active {
-        animation:greenBlinking 1.5s infinite;
-    }
-
-    .live-range-error {
-        animation:redBlinking 1.5s infinite;
-    }
 }
 
 @media screen and (max-width: 858px) {
@@ -70,16 +50,4 @@
         margin-top: 5px !important;
         margin-right: 5px !important;
     }
-}
-
-@keyframes redBlinking{
-    0%{     color: #777;    }
-    50%{    color: var(--red); }
-    100%{   color: #777;    }
-}
-
-@keyframes greenBlinking{
-    0%{     color: #777;    }
-    50%{    color: var(--green); }
-    100%{   color: #777;    }
 }

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -23,6 +23,9 @@ export class TemporalFilterComponent implements OnInit {
     // options for date range selection
     dateRangeOptions: MenuItem[];
 
+    // initial date to show in the calendar
+    defaultDate: Date;
+
     // internal dates for this component
     startDate: Date;
     endDate: Date;
@@ -94,6 +97,9 @@ export class TemporalFilterComponent implements OnInit {
             { label: 'Last 7 days', command: () => { this.selectRange(24 * 7); } },
             { label: 'Last 30 days', command: () => { this.selectRange(24 * 30); } },
         ];
+
+        // set the default date in utc
+        this.defaultDate = UTCDates.localDateToUTC(moment().toDate());
 
         // prevent expression changed error
         setTimeout(() => {

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -1,10 +1,8 @@
-import { Component, EventEmitter, Input, OnInit, OnDestroy, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MessageService } from 'primeng/components/common/messageservice';
-import { Subscription, Observable } from 'rxjs';
 import 'rxjs/add/observable/timer';
 import * as moment from 'moment';
 
-import { LocalStorageItem } from '../../utils/localstorage';
 import { UTCDates } from '../../utils/utcdates';
 
 @Component({
@@ -12,14 +10,10 @@ import { UTCDates } from '../../utils/utcdates';
     templateUrl: './component.html',
     styleUrls: ['./component.scss']
 })
-export class TemporalFilterComponent implements OnInit, OnDestroy {
+export class TemporalFilterComponent implements OnInit {
     @Input() started: string;
     @Input() ended: string;
-    @Input() liveRange: number;
     @Input() loading = false;
-    @Input() localStorageKey = 'temporal-filter';
-    @Input() liveRangeOnly = false;
-    @Input() refreshRate = 10;
 
     // dropdown options for live range, values in hourss
     @Input() dateRangeOptions = [
@@ -34,23 +28,13 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
 
     // when the start/end dates are applied
     @Output() dateFilterSelected: EventEmitter<{start: string, end: string}> = new EventEmitter();
-    // when the live range dropdown value is selected or cleared
-    @Output() liveRangeSelected: EventEmitter<{hours: number}> = new EventEmitter();
     // when the parent component should make an api call to update the data
-    // driven by the timer for the live range update, as well as normal start/end date filter apply
     @Output() updated: EventEmitter<{start: string, end: string}> = new EventEmitter();
 
     selectedDateRange: any;
-    applyBtnClass = 'ui-button-secondary';
-    applyStatusClass = 'live-range-inactive';
-    applyTxtClass = '';
-    liveRangeTooltip = 'No Live Range Selected';
     // internal dates for this component
     startDate: Date;
     endDate: Date;
-
-    // timer subscription, firing when a live range should be changed
-    private liveRangeSubscription: Subscription;
 
     // year range to show in the calendar dropdown
     get yearRange(): string {
@@ -60,37 +44,13 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
         return `${start}:${end}`;
     }
 
-    // dynamic css class to use for live range icon
-    get liveRangeIconClass(): string {
-        if (this.isLiveMode) {
-            if (this.loading) {
-                return 'fa-circle-o-notch fa-spin';
-            } else {
-                return 'fa-circle live-range-active';
-            }
-        }
-        return 'fa-circle live-range-inactive';
-    }
-
     // utc versions of internal start and end dates
     get utcStartDate(): Date { return UTCDates.localDateToUTC(this.startDate); }
     get utcEndDate(): Date { return UTCDates.localDateToUTC(this.endDate); }
 
-    // helper for if a live range is selected
-    get isLiveMode(): boolean { return !!this.liveRange; }
-
-    // used for saving started value into local storage
-    private startedStorage: LocalStorageItem;
-
-    // used for saving ended value into local storage
-    private endedStorage: LocalStorageItem;
-
-    // used for saving live range value into local storage
-    private liveRangeStorage: LocalStorageItem;
-
     // determines if the form inputs are valid
     get isValid(): boolean {
-        if (!this.isLiveMode) {
+        if (this.startDate && this.endDate) {
             return this.startDate < this.endDate;
         }
         return true;
@@ -105,22 +65,11 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
      * Callback for when a normal start/end value is applied
      */
     onDateFilterApply(): void {
-        // normal date filter was applied, turn off live mode
-        this.liveRange = null;
-        this.liveRangeStorage.remove();
-        this.unsubscribe();
-
         // send out the converted date strings
         this.dateFilterSelected.emit({
             start: this.utcStartDate.toISOString(),
             end: this.utcEndDate.toISOString()
         });
-        // ensure the live range will be cleared
-        this.liveRangeSelected.emit({ hours: null });
-
-        // keep values in sync to local storage
-        this.startedStorage.set(this.utcStartDate.toISOString());
-        this.endedStorage.set(this.utcEndDate.toISOString());
 
         if (this.startDate >= this.endDate) {
             this.messageService.add({severity: 'error', summary: 'Error querying range', detail: 'Provided FROM date is before TO date'});
@@ -130,120 +79,33 @@ export class TemporalFilterComponent implements OnInit, OnDestroy {
         }
     }
 
-    private unsubscribe(): void {
-        if (this.liveRangeSubscription) {
-            this.liveRangeSubscription.unsubscribe();
-            this.liveRangeSubscription = null;
-        }
-    }
-
     /**
      * Update hook to emit out the start/end dates the parent component should filter on.
-     * @param now optional param for now for live range, otherwise will use start/end
      */
-    private update(now?: moment.Moment): void {
-        if (now) {
-            this.updated.emit({
-                start: now.clone().subtract(this.liveRange, 'h').toISOString(),
-                end: now.toISOString()
-            });
-        } else {
-            this.updated.emit({
-                start: this.utcStartDate.toISOString(),
-                end: this.utcEndDate.toISOString()
-            });
-        }
-    }
-
-    /**
-     * Callback for when the live range model changes to either emit the value or reset the filter range.
-     */
-    onLiveRangeChange(): void {
-        if (this.liveRange) {
-            // ensure start/end filters are set to empty
-            this.startDate = null;
-            this.endDate = null;
-
-            // emit out the live range selection
-            this.liveRangeSelected.emit({ hours: this.liveRange });
-
-            // save to local storage
-            this.liveRangeStorage.set(this.liveRange);
-
-            // ensure any timers are cancelled, then start a new one
-            this.unsubscribe();
-            this.liveRangeSubscription = Observable.timer(0, this.refreshRate * 1000)
-                .subscribe(() => {
-                    // update using now for the base
-                    this.update(moment.utc());
-                });
-        } else {
-            // live range was cleared, make sure timers are cleared
-            this.unsubscribe();
-
-            // default back to either the supplied start/end date, or from local storage, then from default
-            const now = moment();
-            const start = this.started || this.startedStorage.get() || now.clone().subtract(1, 'day').toDate();
-            const end = this.ended || this.endedStorage.get() || now.toDate();
-            this.startDate = UTCDates.utcDateToLocal(start);
-            this.endDate = UTCDates.utcDateToLocal(end);
-
-            // perform the normal date filter
-            this.onDateFilterApply();
-        }
+    private update(): void {
+        this.updated.emit({
+            start: this.utcStartDate.toISOString(),
+            end: this.utcEndDate.toISOString()
+        });
     }
 
     ngOnInit() {
-        // initialize storage with passed in @Input keys
-        this.startedStorage = new LocalStorageItem('started', this.localStorageKey);
-        this.endedStorage = new LocalStorageItem('ended', this.localStorageKey);
-        this.liveRangeStorage = new LocalStorageItem('range', this.localStorageKey);
-
-        // restrict options for in live range only mode
-        if (this.liveRangeOnly) {
-            this.dateRangeOptions = this.dateRangeOptions.filter(d => d.value);
-        }
-
         // prevent expression changed error
         setTimeout(() => {
-            if (this.liveRange) {
-                // live range was set from parent (router)
-                this.liveRangeStorage.set(this.liveRange);
-                this.onLiveRangeChange();
-            } else if (!this.liveRangeOnly && this.started && this.ended) {
+            if (this.started && this.ended) {
                 // start/end dates were set from parent (router)
                 this.startDate = UTCDates.utcDateToLocal(this.started);
                 this.endDate = UTCDates.utcDateToLocal(this.ended);
                 this.onDateFilterApply();
-            } else if (this.liveRangeStorage.get()) {
-                // live range and start/end not provided by parent
-                // live range available in localstorage
-                this.liveRange = this.liveRangeStorage.get();
-                this.onLiveRangeChange();
-            } else if (this.startedStorage.get() && this.endedStorage.get()) {
-                // start/end provided from localstorage
-                this.startDate = UTCDates.utcDateToLocal(this.startedStorage.get());
-                this.endDate = UTCDates.utcDateToLocal(this.endedStorage.get());
-                this.onDateFilterApply();
             } else {
-                if (this.liveRangeOnly) {
-                    // force using the live range value, provide a default
-                    this.liveRange = this.dateRangeOptions[0].value;
-                    this.onLiveRangeChange();
-                } else {
-                    // nothing provided by parent component or found in storage
-                    // use date filter on the last day
-                    const now = moment();
-                    this.endDate = now.toDate();
-                    this.startDate = now.clone().subtract(1, 'day').toDate();
-                    this.onDateFilterApply();
-                }
+                // nothing provided by parent component or found in storage
+                // use date filter on the last day
+                const now = moment();
+                this.endDate = now.toDate();
+                this.startDate = now.clone().subtract(1, 'day').toDate();
+                this.onDateFilterApply();
             }
         });
-    }
-
-    ngOnDestroy() {
-        this.unsubscribe();
     }
 
 }

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -140,6 +140,7 @@ export class TemporalFilterComponent implements OnInit {
 
             if (isNil(this.started)) {
                 // started is null or undefined, provide a default
+                // default to 24 hours prior to now
                 this.startDate = UTCDates.utcDateToLocal(now.clone().subtract(1, 'day').toDate());
             } else if (this.started) {
                 // started is probably a date, convert
@@ -148,7 +149,8 @@ export class TemporalFilterComponent implements OnInit {
             // else, started is an empty string, keep as null
 
             if (isNil(this.ended)) {
-                this.endDate = UTCDates.utcDateToLocal(now.toDate());
+                // default to the end of today, 23:59:59
+                this.endDate = UTCDates.utcDateToLocal(now.clone().endOf('day').toDate());
             } else if (this.ended) {
                 this.endDate = UTCDates.utcDateToLocal(this.ended);
             }

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MessageService } from 'primeng/components/common/messageservice';
+import { MenuItem } from 'primeng/api';
 import 'rxjs/add/observable/timer';
 import * as moment from 'moment';
 import { isNil } from 'lodash';
@@ -16,19 +17,11 @@ export class TemporalFilterComponent implements OnInit {
     @Input() ended: string;
     @Input() loading = false;
 
-    // dropdown options for live range, values in hourss
-    @Input() dateRangeOptions = [
-        { label: '---', value: null },
-        { label: 'Last 1 hour', value: 1 },
-        { label: 'Last 6 hours', value: 6 },
-        { label: 'Last 12 hours', value: 12 },
-        { label: 'Last day', value: 24 },
-        { label: 'Last 3 days', value: 24 * 3 },
-        { label: 'Last week', value: 24 * 7 }
-    ];
-
     // when the parent component should make an api call to update the data
     @Output() updated: EventEmitter<{start: string, end: string}> = new EventEmitter();
+
+    // options for date range selection
+    dateRangeOptions: MenuItem[];
 
     // internal dates for this component
     startDate: Date;
@@ -79,7 +72,29 @@ export class TemporalFilterComponent implements OnInit {
         }
     }
 
+    /**
+     * Sets a range using now for the end date and offsetting by the number of hours.
+     * @param hours number of hours prior to now for the start date
+     */
+    private selectRange(hours: number): void {
+        const now = moment.utc();
+        this.startDate = UTCDates.localDateToUTC(now.clone().subtract(hours, 'hour').toDate());
+        this.endDate = UTCDates.localDateToUTC(this.endDate = now.toDate());
+        this.onDateFilterApply();
+    }
+
     ngOnInit() {
+        // setup date range options
+        this.dateRangeOptions = [
+            { label: 'Last hour', command: () => { this.selectRange(1); } },
+            { label: 'Last 6 hours', command: () => { this.selectRange(6); } },
+            { label: 'Last 12 hours', command: () => { this.selectRange(12); } },
+            { label: 'Last day', command: () => { this.selectRange(24); } },
+            { label: 'Last 3 days', command: () => { this.selectRange(24 * 3); } },
+            { label: 'Last 7 days', command: () => { this.selectRange(24 * 7); } },
+            { label: 'Last 30 days', command: () => { this.selectRange(24 * 30); } },
+        ];
+
         // prevent expression changed error
         setTimeout(() => {
             const now = moment();

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MessageService } from 'primeng/components/common/messageservice';
 import { MenuItem } from 'primeng/api';
-import 'rxjs/add/observable/timer';
 import * as moment from 'moment';
 import { isNil } from 'lodash';
 

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -107,7 +107,7 @@ export class TemporalFilterComponent implements OnInit {
 
             if (isNil(this.started)) {
                 // started is null or undefined, provide a default
-                this.startDate = now.clone().subtract(1, 'day').toDate();
+                this.startDate = UTCDates.utcDateToLocal(now.clone().subtract(1, 'day').toDate());
             } else if (this.started) {
                 // started is probably a date, convert
                 this.startDate = UTCDates.utcDateToLocal(this.started);
@@ -115,7 +115,7 @@ export class TemporalFilterComponent implements OnInit {
             // else, started is an empty string, keep as null
 
             if (isNil(this.ended)) {
-                this.endDate = now.toDate();
+                this.endDate = UTCDates.utcDateToLocal(now.toDate());
             } else if (this.ended) {
                 this.endDate = UTCDates.utcDateToLocal(this.ended);
             }

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -80,9 +80,9 @@ export class TemporalFilterComponent implements OnInit {
      * @param hours number of hours prior to now for the start date
      */
     private selectRange(hours: number): void {
-        const now = moment.utc();
-        this.startDate = UTCDates.localDateToUTC(now.clone().subtract(hours, 'hour').toDate());
-        this.endDate = UTCDates.localDateToUTC(this.endDate = now.toDate());
+        const now = moment();
+        this.startDate = UTCDates.utcDateToLocal(now.clone().subtract(hours, 'hour').toDate());
+        this.endDate = UTCDates.utcDateToLocal(now.toDate());
         this.onDateFilterApply();
     }
 

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -3,6 +3,8 @@ import { MessageService } from 'primeng/components/common/messageservice';
 import { MenuItem } from 'primeng/api';
 import * as moment from 'moment';
 import { isNil } from 'lodash';
+import { Subject } from 'rxjs/Subject';
+import { debounceTime, distinctUntilChanged } from 'rxjs/internal/operators';
 
 import { UTCDates } from '../../utils/utcdates';
 
@@ -28,6 +30,10 @@ export class TemporalFilterComponent implements OnInit {
     // internal dates for this component
     startDate: Date;
     endDate: Date;
+
+    // subjects for watching when start/end input fields change
+    private startChanged: Subject<Date> = new Subject();
+    private endChanged: Subject<Date> = new Subject();
 
     // year range to show in the calendar dropdown
     get yearRange(): string {
@@ -56,6 +62,31 @@ export class TemporalFilterComponent implements OnInit {
     constructor(
         private messageService: MessageService
     ) {
+        // debounceTime - prevent sending updates too quickly
+        // distinctUntilChanged - only send updates when value has changed
+        const waitTime = 750;
+        this.startChanged
+            .pipe(debounceTime(waitTime), distinctUntilChanged())
+            .subscribe(() => this.onDateFilterApply());
+        this.endChanged
+            .pipe(debounceTime(waitTime), distinctUntilChanged())
+            .subscribe(() => this.onDateFilterApply());
+    }
+
+    /**
+     * Callback for when start calendar/input field is changed.
+     * @param date [description]
+     */
+    onStartChange(date: Date): void {
+        this.startChanged.next(date);
+    }
+
+    /**
+     * Callback for when end calendar/input field is changed.
+     * @param date [description]
+     */
+    onEndChange(date: Date): void {
+        this.startChanged.next(date);
     }
 
     /**

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MessageService } from 'primeng/components/common/messageservice';
-import { MenuItem } from 'primeng/api';
 import * as moment from 'moment';
 import { isNil } from 'lodash';
 import { Subject } from 'rxjs/Subject';
@@ -22,7 +21,7 @@ export class TemporalFilterComponent implements OnInit {
     @Output() updated: EventEmitter<{start: string, end: string}> = new EventEmitter();
 
     // options for date range selection
-    dateRangeOptions: MenuItem[];
+    dateRangeOptions: any;
 
     // initial date to show in the calendar
     defaultDate: Date;
@@ -34,6 +33,8 @@ export class TemporalFilterComponent implements OnInit {
     // subjects for watching when start/end input fields change
     private startChanged: Subject<Date> = new Subject();
     private endChanged: Subject<Date> = new Subject();
+
+    showHighlight = false;
 
     // year range to show in the calendar dropdown
     get yearRange(): string {
@@ -109,23 +110,25 @@ export class TemporalFilterComponent implements OnInit {
      * Sets a range using now for the end date and offsetting by the number of hours.
      * @param hours number of hours prior to now for the start date
      */
-    private selectRange(hours: number): void {
+    selectRange(hours: number): void {
         const now = moment();
         this.startDate = UTCDates.utcDateToLocal(now.clone().subtract(hours, 'hour').toDate());
         this.endDate = UTCDates.utcDateToLocal(now.toDate());
         this.onDateFilterApply();
+
+        // highlight the start/end inputs
+        this.showHighlight = true;
+        setTimeout(() => {
+            this.showHighlight = false;
+        }, 400);
     }
 
     ngOnInit() {
         // setup date range options
         this.dateRangeOptions = [
-            { label: 'Last hour', command: () => { this.selectRange(1); } },
-            { label: 'Last 6 hours', command: () => { this.selectRange(6); } },
-            { label: 'Last 12 hours', command: () => { this.selectRange(12); } },
-            { label: 'Last day', command: () => { this.selectRange(24); } },
-            { label: 'Last 3 days', command: () => { this.selectRange(24 * 3); } },
-            { label: 'Last 7 days', command: () => { this.selectRange(24 * 7); } },
-            { label: 'Last 30 days', command: () => { this.selectRange(24 * 30); } },
+            { label: '1 hour', value: 1 },
+            { label: '12 hours', value: 12 },
+            { label: '24 hours', value: 24 },
         ];
 
         // set the default date in utc

--- a/projects/developer/src/app/dashboard/component.html
+++ b/projects/developer/src/app/dashboard/component.html
@@ -1,15 +1,14 @@
 <div class="dashboard">
     <div class="p-grid">
         <div class="p-col-12 p-md-12 p-lg-3 p-xl-3">
-        </div> 
+        </div>
         <div class="p-col-12 p-md-12 p-lg-9 p-xl-9">
-            <dev-temporal-filter
+            <dev-live-range-selector
                 localStorageKey="dashboard-filter"
-                [liveRangeOnly]="true"
                 (updated)="onTemporalFilterUpdate($event)"
-                refreshRate="600"
+                [refreshRate]="600"
                 [dateRangeOptions]="dateRangeOptions">
-            </dev-temporal-filter>
+            </dev-live-range-selector>
         </div>
         <div class="p-col-12 p-md-12 p-lg-3 p-xl-3 dashboard__error-charts">
                 <div class="charts" *ngIf="favoriteJobTypes.length == 0">
@@ -36,7 +35,7 @@
                                     <span>No Jobs are currently running.</span>
                                </div>
                             </p-tabPanel>
-                            
+
                         </p-tabView>
                     </p-panel>
                 </div>
@@ -131,7 +130,7 @@
                         <p-tabPanel [header]="'All Jobs'">
                             <dev-job-activity [started]="started" [ended]="ended" ></dev-job-activity>
                         </p-tabPanel>
-                        
+
                     </p-tabView>
                 </p-panel>
             </div>

--- a/projects/developer/src/app/data/ingest/component.html
+++ b/projects/developer/src/app/data/ingest/component.html
@@ -2,7 +2,6 @@
 <div class="ingest__header flexed space-between">
     <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
-                         (dateFilterSelected)="onDateFilterSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
 </div>

--- a/projects/developer/src/app/data/ingest/component.html
+++ b/projects/developer/src/app/data/ingest/component.html
@@ -1,9 +1,8 @@
 <h2><i class="fa fa-clone"></i> Ingest Records <span *ngIf="count">({{ count }})</span></h2>
 <div class="ingest__header flexed space-between">
-    <dev-temporal-filter [started]="started" [ended]="ended" [liveRange]="liveRange"
+    <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
                          (dateFilterSelected)="onDateFilterSelected($event)"
-                         (liveRangeSelected)="onLiveRangeSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
 </div>

--- a/projects/developer/src/app/data/ingest/component.ts
+++ b/projects/developer/src/app/data/ingest/component.ts
@@ -79,7 +79,6 @@ export class IngestComponent implements OnInit, OnDestroy {
         });
         this.updateOptions();
     }, 1000);
-    liveRange: number;
 
     constructor(
         private dataService: DataService,
@@ -94,11 +93,7 @@ export class IngestComponent implements OnInit, OnDestroy {
 
     private updateData() {
         this.unsubscribe();
-
-        // don't show loading state when in live mode
-        if (!this.liveRange) {
-            this.datatableLoading = true;
-        }
+        this.datatableLoading = true;
 
         this.apiLoading = true;
         this.subscription = this.ingestApiService.getIngests(this.datatableOptions, true).subscribe(data => {
@@ -124,15 +119,8 @@ export class IngestComponent implements OnInit, OnDestroy {
 
         // update router params
         const params = this.datatableOptions as Params;
-        if (params.liveRange) {
-            // if live range was set on the table options, remove started/ended
-            delete params.started;
-            delete params.ended;
-        } else {
-            // live range not provided, default back to started/ended set on table options
-            params.started = params.started || this.started;
-            params.ended = params.ended || this.ended;
-        }
+        params.started = params.started || this.started;
+        params.ended = params.ended || this.ended;
 
         this.router.navigate(['/data/ingest'], {
             queryParams: params,
@@ -247,21 +235,6 @@ export class IngestComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Callback for temporal filter updating the live range selection.
-     * @param data hours that should be used, or null to clear
-     */
-    onLiveRangeSelected(data: {hours: number}): void {
-        // keep model in sync
-        this.liveRange = data.hours;
-        // patch in the values for datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            liveRange: data.hours
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
      * Callback for when temporal filter tells this component to update visible date range. This is
      * the signal that either a date range or a live range is being triggered.
      * @param data start and end iso strings for what dates should be filtered
@@ -301,7 +274,6 @@ export class IngestComponent implements OnInit, OnDestroy {
                     sortOrder: params.sortOrder ? parseInt(params.sortOrder, 10) : -1,
                     started: params.started || this.datatableOptions.started,
                     ended: params.ended || this.datatableOptions.ended,
-                    liveRange: params.liveRange ? parseInt(params.liveRange, 10) : null,
                     duration: params.duration ? params.duration : null,
                     status: params.status ?
                         Array.isArray(params.status) ?
@@ -329,7 +301,6 @@ export class IngestComponent implements OnInit, OnDestroy {
             });
             this.started = this.datatableOptions.started;
             this.ended = this.datatableOptions.ended;
-            this.liveRange = this.datatableOptions.liveRange;
             this.getStrikes();
         });
     }

--- a/projects/developer/src/app/data/ingest/component.ts
+++ b/projects/developer/src/app/data/ingest/component.ts
@@ -226,6 +226,9 @@ export class IngestComponent implements OnInit, OnDestroy {
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // determine if values have changed
+        const isSame = this.started === data.start && this.ended === data.end;
+
         // keep local model in sync
         this.started = data.start;
         this.ended = data.end;
@@ -235,6 +238,12 @@ export class IngestComponent implements OnInit, OnDestroy {
                 ended: data.end
             });
         this.updateOptions();
+
+        // updateOptions will only cause a data refresh if the route params are different
+        // force a data update only when the params haven't changed
+        if (isSame) {
+            this.updateData();
+        }
     }
 
     onFilterClick(e) {

--- a/projects/developer/src/app/data/ingest/datatable.service.ts
+++ b/projects/developer/src/app/data/ingest/datatable.service.ts
@@ -23,6 +23,10 @@ export class IngestDatatableService {
 
     setIngestDatatableOptions(params: IngestDatatable): void {
         this.ingestDatatable = params;
+
+        // don't let started/ended params persist in local storage
+        delete params.started;
+        delete params.ended;
         this.storage.set(params);
     }
 }

--- a/projects/developer/src/app/processing/batches/batches-component.html
+++ b/projects/developer/src/app/processing/batches/batches-component.html
@@ -2,7 +2,6 @@
 <div class="batches__header flexed space-between">
     <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
-                         (dateFilterSelected)="onDateFilterSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
     <div class="batches__controls">

--- a/projects/developer/src/app/processing/batches/batches-component.html
+++ b/projects/developer/src/app/processing/batches/batches-component.html
@@ -1,9 +1,8 @@
 <h2><i class="fa fa-files-o"></i> Batches <span *ngIf="count">({{ count }})</span></h2>
 <div class="batches__header flexed space-between">
-    <dev-temporal-filter [started]="started" [ended]="ended" [liveRange]="liveRange"
+    <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
                          (dateFilterSelected)="onDateFilterSelected($event)"
-                         (liveRangeSelected)="onLiveRangeSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
     <div class="batches__controls">

--- a/projects/developer/src/app/processing/batches/batches-component.ts
+++ b/projects/developer/src/app/processing/batches/batches-component.ts
@@ -175,6 +175,9 @@ export class BatchesComponent implements OnInit, OnDestroy {
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // determine if values have changed
+        const isSame = this.started === data.start && this.ended === data.end;
+
         // keep local model in sync
         this.started = data.start;
         this.ended = data.end;
@@ -184,6 +187,12 @@ export class BatchesComponent implements OnInit, OnDestroy {
                 ended: data.end
             });
         this.updateOptions();
+
+        // updateOptions will only cause a data refresh if the route params are different
+        // force a data update only when the params haven't changed
+        if (isSame) {
+            this.updateData();
+        }
     }
 
     ngOnInit() {

--- a/projects/developer/src/app/processing/batches/batches-component.ts
+++ b/projects/developer/src/app/processing/batches/batches-component.ts
@@ -45,7 +45,6 @@ export class BatchesComponent implements OnInit, OnDestroy {
     isInitialized = false;
     subscription: any;
     isMobile: boolean;
-    liveRange: number;
 
     constructor(
         private dataService: DataService,
@@ -60,11 +59,7 @@ export class BatchesComponent implements OnInit, OnDestroy {
 
     private updateData() {
         this.unsubscribe();
-
-        // don't show loading state when in live mode
-        if (!this.liveRange) {
-            this.datatableLoading = true;
-        }
+        this.datatableLoading = true;
 
         this.apiLoading = true;
         this.subscription = this.batchesApiService.getBatches(this.datatableOptions, true).subscribe(data => {
@@ -90,15 +85,8 @@ export class BatchesComponent implements OnInit, OnDestroy {
 
         // update router params
         const params = this.datatableOptions as Params;
-        if (params.liveRange) {
-            // if live range was set on the table options, remove started/ended
-            delete params.started;
-            delete params.ended;
-        } else {
-            // live range not provided, default back to started/ended set on table options
-            params.started = params.started || this.started;
-            params.ended = params.ended || this.ended;
-        }
+        params.started = params.started || this.started;
+        params.ended = params.ended || this.ended;
 
         this.router.navigate(['/processing/batches'], {
             queryParams: params,
@@ -196,21 +184,6 @@ export class BatchesComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Callback for temporal filter updating the live range selection.
-     * @param data hours that should be used, or null to clear
-     */
-    onLiveRangeSelected(data: {hours: number}): void {
-        // keep model in sync
-        this.liveRange = data.hours;
-        // patch in the values for datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            liveRange: data.hours
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
      * Callback for when temporal filter tells this component to update visible date range. This is
      * the signal that either a date range or a live range is being triggered.
      * @param data start and end iso strings for what dates should be filtered
@@ -249,7 +222,6 @@ export class BatchesComponent implements OnInit, OnDestroy {
                     sortOrder: params.sortOrder ? parseInt(params.sortOrder, 10) : -1,
                     started: params.started || this.datatableOptions.started,
                     ended: params.ended || this.datatableOptions.ended,
-                    liveRange: params.liveRange ? parseInt(params.liveRange, 10) : null,
                     duration: params.duration ? params.duration : null,
                     recipe_type_id: params.recipe_type_id ?
                         Array.isArray(params.recipe_type_id) ?
@@ -263,7 +235,6 @@ export class BatchesComponent implements OnInit, OnDestroy {
             }
             this.started = this.datatableOptions.started;
             this.ended = this.datatableOptions.ended;
-            this.liveRange = this.datatableOptions.liveRange;
             this.getRecipeTypes();
         });
     }

--- a/projects/developer/src/app/processing/batches/datatable.service.ts
+++ b/projects/developer/src/app/processing/batches/datatable.service.ts
@@ -23,6 +23,10 @@ export class BatchesDatatableService {
 
     setBatchesDatatableOptions(params: BatchesDatatable): void {
         this.batchesDatatable = params;
+
+        // don't let started/ended params persist in local storage
+        delete params.started;
+        delete params.ended;
         this.storage.set(params);
     }
 }

--- a/projects/developer/src/app/processing/jobs/component.html
+++ b/projects/developer/src/app/processing/jobs/component.html
@@ -2,7 +2,6 @@
 <div class="jobs__header flexed space-between">
     <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
-                         (dateFilterSelected)="onDateFilterSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
 

--- a/projects/developer/src/app/processing/jobs/component.html
+++ b/projects/developer/src/app/processing/jobs/component.html
@@ -6,10 +6,17 @@
     </dev-temporal-filter>
 
     <div class="jobs__controls">
-        <button pButton type="button" class="ui-button-primary" icon="fa fa-repeat" pTooltip="Requeue All Jobs"
-                (click)="requeueAllConfirm()"></button>
-        <button pButton type="button" class="ui-button-primary" icon="fa fa-ban" pTooltip="Cancel All Jobs"
-                (click)="cancelAllConfirm()"></button>
+
+        <p-menu #actionsMenu
+                [popup]="true"
+                [model]="actionItems"></p-menu>
+        <button type="button"
+                pButton
+                label="Actions"
+                icon="fa fa-caret-down"
+                iconPos="right"
+                class="ui-button-secondary"
+                (click)="actionsMenu.toggle($event)"></button>
     </div>
 </div>
 <p-table [value]="jobs" [columns]="columns" [rows]="datatableOptions.rows" [sortField]="datatableOptions.sortField"

--- a/projects/developer/src/app/processing/jobs/component.html
+++ b/projects/developer/src/app/processing/jobs/component.html
@@ -1,9 +1,8 @@
 <h2><i class="fa fa-cube"></i> Jobs <span *ngIf="count">({{ count }})</span></h2>
 <div class="jobs__header flexed space-between">
-    <dev-temporal-filter [started]="started" [ended]="ended" [liveRange]="liveRange"
+    <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
                          (dateFilterSelected)="onDateFilterSelected($event)"
-                         (liveRangeSelected)="onLiveRangeSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
 

--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -86,7 +86,6 @@ export class JobsComponent implements OnInit, OnDestroy {
     isInitialized = false;
     subscription: any;
     isMobile: boolean;
-    liveRange: number;
 
     constructor(
         private dataService: DataService,
@@ -102,11 +101,7 @@ export class JobsComponent implements OnInit, OnDestroy {
 
     private updateData() {
         this.unsubscribe();
-
-        // don't show loading state when in live mode
-        if (!this.liveRange) {
-            this.datatableLoading = true;
-        }
+        this.datatableLoading = true;
 
         this.apiLoading = true;
         this.subscription = this.jobsApiService.getJobs(this.datatableOptions, true).subscribe(data => {
@@ -133,15 +128,8 @@ export class JobsComponent implements OnInit, OnDestroy {
 
         // update router params
         const params = this.datatableOptions as Params;
-        if (params.liveRange) {
-            // if live range was set on the table options, remove started/ended
-            delete params.started;
-            delete params.ended;
-        } else {
-            // live range not provided, default back to started/ended set on table options
-            params.started = params.started || this.started;
-            params.ended = params.ended || this.ended;
-        }
+        params.started = params.started || this.started;
+        params.ended = params.ended || this.ended;
 
         this.router.navigate(['/processing/jobs'], {
             queryParams: params,
@@ -252,21 +240,6 @@ export class JobsComponent implements OnInit, OnDestroy {
         this.datatableOptions = Object.assign(this.datatableOptions, {
             started: data.start,
             ended: data.end
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
-     * Callback for temporal filter updating the live range selection.
-     * @param data hours that should be used, or null to clear
-     */
-    onLiveRangeSelected(data: {hours: number}): void {
-        // keep model in sync
-        this.liveRange = data.hours;
-        // patch in the values for datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            liveRange: data.hours
         });
         // update router
         this.updateOptions();
@@ -445,7 +418,6 @@ export class JobsComponent implements OnInit, OnDestroy {
                     sortOrder: params.sortOrder ? parseInt(params.sortOrder, 10) : -1,
                     started: params.started || this.datatableOptions.started,
                     ended: params.ended || this.datatableOptions.ended,
-                    liveRange: params.liveRange ? parseInt(params.liveRange, 10) : null,
                     status: params.status ?
                         Array.isArray(params.status) ?
                             params.status :
@@ -484,7 +456,6 @@ export class JobsComponent implements OnInit, OnDestroy {
                 : null;
             this.started = this.datatableOptions.started;
             this.ended = this.datatableOptions.ended;
-            this.liveRange = this.datatableOptions.liveRange;
 
             this.getJobTypes();
         });

--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
-import { LazyLoadEvent, SelectItem } from 'primeng/api';
+import { LazyLoadEvent, SelectItem, MenuItem } from 'primeng/api';
 import { ConfirmationService } from 'primeng/api';
 import { MessageService } from 'primeng/components/common/messageservice';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
@@ -86,6 +86,7 @@ export class JobsComponent implements OnInit, OnDestroy {
     isInitialized = false;
     subscription: any;
     isMobile: boolean;
+    actionItems: MenuItem[];
 
     constructor(
         private dataService: DataService,
@@ -395,6 +396,11 @@ export class JobsComponent implements OnInit, OnDestroy {
         this.onJobTypeChange({ value: this.selectedJobType });
     }
     ngOnInit() {
+        this.actionItems = [
+            { label: 'Requeue all', icon: 'fa fa-repeat', command: () => { this.requeueAllConfirm(); } },
+            { label: 'Cancel all', icon: 'fa fa-ban', command: () => { this.cancelAllConfirm(); } },
+        ];
+
         this.selectedRows = this.dataService.getSelectedJobRows();
 
         this.breakpointObserver.observe(['(min-width: 1275px)']).subscribe((state: BreakpointState) => {

--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -238,6 +238,9 @@ export class JobsComponent implements OnInit, OnDestroy {
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // determine if values have changed
+        const isSame = this.started === data.start && this.ended === data.end;
+
         // keep local model in sync
         this.started = data.start;
         this.ended = data.end;
@@ -248,6 +251,12 @@ export class JobsComponent implements OnInit, OnDestroy {
                 ended: data.end
             });
         this.updateOptions();
+
+        // updateOptions will only cause a data refresh if the route params are different
+        // force a data update only when the params haven't changed
+        if (isSame) {
+            this.updateData();
+        }
     }
 
     requeueJobs(jobsParams?) {

--- a/projects/developer/src/app/processing/jobs/datatable.service.ts
+++ b/projects/developer/src/app/processing/jobs/datatable.service.ts
@@ -23,6 +23,10 @@ export class JobsDatatableService {
 
     setJobsDatatableOptions(params: JobsDatatable): void {
         this.jobsDatatable = params;
+
+        // don't let started/ended params persist in local storage
+        delete params.started;
+        delete params.ended;
         this.storage.set(params);
     }
 }

--- a/projects/developer/src/app/processing/recipes/component.html
+++ b/projects/developer/src/app/processing/recipes/component.html
@@ -2,7 +2,6 @@
 <div class="recipes__header flexed space-between">
     <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
-                         (dateFilterSelected)="onDateFilterSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
 </div>

--- a/projects/developer/src/app/processing/recipes/component.html
+++ b/projects/developer/src/app/processing/recipes/component.html
@@ -1,9 +1,8 @@
 <h2><i class="fa fa-cubes"></i> Recipes</h2>
 <div class="recipes__header flexed space-between">
-    <dev-temporal-filter [started]="started" [ended]="ended" [liveRange]="liveRange"
+    <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
                          (dateFilterSelected)="onDateFilterSelected($event)"
-                         (liveRangeSelected)="onLiveRangeSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
 </div>

--- a/projects/developer/src/app/processing/recipes/component.ts
+++ b/projects/developer/src/app/processing/recipes/component.ts
@@ -170,6 +170,9 @@ export class RecipesComponent implements OnInit, OnDestroy {
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // determine if values have changed
+        const isSame = this.started === data.start && this.ended === data.end;
+
         // keep local model in sync
         this.started = data.start;
         this.ended = data.end;
@@ -179,6 +182,12 @@ export class RecipesComponent implements OnInit, OnDestroy {
                 ended: data.end
             });
         this.updateOptions();
+
+        // updateOptions will only cause a data refresh if the route params are different
+        // force a data update only when the params haven't changed
+        if (isSame) {
+            this.updateData();
+        }
     }
 
     onClick(e) {

--- a/projects/developer/src/app/processing/recipes/component.ts
+++ b/projects/developer/src/app/processing/recipes/component.ts
@@ -45,7 +45,6 @@ export class RecipesComponent implements OnInit, OnDestroy {
     isInitialized = false;
     subscription: any;
     isMobile: boolean;
-    liveRange: number;
 
     constructor(
         private dataService: DataService,
@@ -60,12 +59,7 @@ export class RecipesComponent implements OnInit, OnDestroy {
 
     private updateData() {
         this.unsubscribe();
-
-        // don't show loading state when in live mode
-        if (!this.liveRange) {
-            this.datatableLoading = true;
-        }
-
+        this.datatableLoading = true;
         this.apiLoading = true;
         this.subscription = this.recipesApiService.getRecipes(this.datatableOptions, true).subscribe(data => {
             this.datatableLoading = false;
@@ -90,15 +84,9 @@ export class RecipesComponent implements OnInit, OnDestroy {
 
         // update router params
         const params = this.datatableOptions as Params;
-        if (params.liveRange) {
-            // if live range was set on the table options, remove started/ended
-            delete params.started;
-            delete params.ended;
-        } else {
-            // live range not provided, default back to started/ended set on table options
-            params.started = params.started || this.started;
-            params.ended = params.ended || this.ended;
-        }
+        // live range not provided, default back to started/ended set on table options
+        params.started = params.started || this.started;
+        params.ended = params.ended || this.ended;
 
         // update querystring
         this.router.navigate(['/processing/recipes'], {
@@ -191,21 +179,6 @@ export class RecipesComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Callback for temporal filter updating the live range selection.
-     * @param data hours that should be used, or null to clear
-     */
-    onLiveRangeSelected(data: {hours: number}): void {
-        // keep model in sync
-        this.liveRange = data.hours;
-        // patch in the values for datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            liveRange: data.hours
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
      * Callback for when temporal filter tells this component to update visible date range. This is
      * the signal that either a date range or a live range is being triggered.
      * @param data start and end iso strings for what dates should be filtered
@@ -244,7 +217,6 @@ export class RecipesComponent implements OnInit, OnDestroy {
                     sortOrder: +params.sortOrder || -1,
                     started: params.started || this.datatableOptions.started,
                     ended: params.ended || this.datatableOptions.ended,
-                    liveRange: params.liveRange ? parseInt(params.liveRange, 10) : null,
                     duration: params.duration ? params.duration : null,
                     recipe_type_id: +params.recipe_type_id || null,
                     recipe_type_name: params.recipe_type_name ?
@@ -260,7 +232,6 @@ export class RecipesComponent implements OnInit, OnDestroy {
             }
             this.started = this.datatableOptions.started;
             this.ended = this.datatableOptions.ended;
-            this.liveRange = this.datatableOptions.liveRange;
             this.getRecipeTypes();
         });
     }

--- a/projects/developer/src/app/processing/recipes/component.ts
+++ b/projects/developer/src/app/processing/recipes/component.ts
@@ -77,7 +77,11 @@ export class RecipesComponent implements OnInit, OnDestroy {
         });
     }
     private updateOptions() {
-        this.datatableOptions = _.pickBy(this.datatableOptions, (d) => {
+        this.datatableOptions = _.pickBy(this.datatableOptions, (d, idx) => {
+            if (idx === 'started' || idx === 'ended') {
+                // allow started and ended to be empty
+                return d;
+            }
             return d !== null && typeof d !== 'undefined' && d !== '';
         }) as RecipesDatatable;
         this.recipesDatatableService.setRecipesDatatableOptions(this.datatableOptions);
@@ -162,35 +166,19 @@ export class RecipesComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Callback for temporal filter updating the start/end range filter.
-     * @param data start and end strings of iso formatted datetimes
-     */
-    onDateFilterSelected(data: {start: string, end: string}): void {
-        // keep local model in sync
-        this.started = data.start;
-        this.ended = data.end;
-        // patch in the values to the datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            started: data.start,
-            ended: data.end
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
-     * Callback for when temporal filter tells this component to update visible date range. This is
-     * the signal that either a date range or a live range is being triggered.
+     * Callback for when temporal filter tells this component to update visible date range.
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // keep local model in sync
+        this.started = data.start;
+        this.ended = data.end;
         // update the datatable options then call the api
         this.datatableOptions = Object.assign(this.datatableOptions, {
-                first: 0,
                 started: data.start,
                 ended: data.end
             });
-        this.updateData();
+        this.updateOptions();
     }
 
     onClick(e) {
@@ -204,9 +192,6 @@ export class RecipesComponent implements OnInit, OnDestroy {
         });
 
         this.datatableOptions = this.recipesDatatableService.getRecipesDatatableOptions();
-        // let temporal filter set the start/end
-        this.datatableOptions.started = null;
-        this.datatableOptions.ended = null;
 
         this.route.queryParams.subscribe(params => {
             if (Object.keys(params).length > 0) {
@@ -215,8 +200,8 @@ export class RecipesComponent implements OnInit, OnDestroy {
                     rows: +params.rows || 10,
                     sortField: params.sortField || 'last_modified',
                     sortOrder: +params.sortOrder || -1,
-                    started: params.started || this.datatableOptions.started,
-                    ended: params.ended || this.datatableOptions.ended,
+                    started:  this.datatableOptions.started || params.started,
+                    ended: this.datatableOptions.ended || params.ended,
                     duration: params.duration ? params.duration : null,
                     recipe_type_id: +params.recipe_type_id || null,
                     recipe_type_name: params.recipe_type_name ?

--- a/projects/developer/src/app/processing/recipes/datatable.service.ts
+++ b/projects/developer/src/app/processing/recipes/datatable.service.ts
@@ -23,6 +23,10 @@ export class RecipesDatatableService {
 
     setRecipesDatatableOptions(params: RecipesDatatable): void {
         this.recipesDatatable = params;
+
+        // don't let started/ended params persist in local storage
+        delete params.started;
+        delete params.ended;
         this.storage.set(params);
     }
 }

--- a/projects/developer/src/app/system/scans/component.html
+++ b/projects/developer/src/app/system/scans/component.html
@@ -1,9 +1,8 @@
 <h2><i class="fa fa-barcode"></i> Scans <span *ngIf="count">({{ count }})</span></h2>
 <div class="scans__header flexed space-between">
-    <dev-temporal-filter [started]="started" [ended]="ended" [liveRange]="liveRange"
+    <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
                          (dateFilterSelected)="onDateFilterSelected($event)"
-                         (liveRangeSelected)="onLiveRangeSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
     <div class="scans__controls">

--- a/projects/developer/src/app/system/scans/component.html
+++ b/projects/developer/src/app/system/scans/component.html
@@ -2,7 +2,6 @@
 <div class="scans__header flexed space-between">
     <dev-temporal-filter [started]="started" [ended]="ended"
                          [loading]="apiLoading"
-                         (dateFilterSelected)="onDateFilterSelected($event)"
                          (updated)="onTemporalFilterUpdate($event)">
     </dev-temporal-filter>
     <div class="scans__controls">

--- a/projects/developer/src/app/system/scans/component.ts
+++ b/projects/developer/src/app/system/scans/component.ts
@@ -35,7 +35,6 @@ export class ScansComponent implements OnInit, OnDestroy {
     isInitialized = false;
     subscription: any;
     isMobile: boolean;
-    liveRange: number;
 
     nameFilterText: string;
     onNameFilter = _.debounce((e) => {
@@ -60,11 +59,7 @@ export class ScansComponent implements OnInit, OnDestroy {
 
     private updateData() {
         this.unsubscribe();
-
-        // don't show loading state when in live mode
-        if (!this.liveRange) {
-            this.datatableLoading = true;
-        }
+        this.datatableLoading = true;
 
         this.apiLoading = true;
         this.subscription = this.scansApiService.getScans(this.datatableOptions, true).subscribe(data => {
@@ -91,15 +86,8 @@ export class ScansComponent implements OnInit, OnDestroy {
 
         // update router params
         const params = this.datatableOptions as Params;
-        if (params.liveRange) {
-            // if live range was set on the table options, remove started/ended
-            delete params.started;
-            delete params.ended;
-        } else {
-            // live range not provided, default back to started/ended set on table options
-            params.started = params.started || this.started;
-            params.ended = params.ended || this.ended;
-        }
+        params.started = params.started || this.started;
+        params.ended = params.ended || this.ended;
 
         this.router.navigate(['/system/scans'], {
             queryParams: params,
@@ -166,21 +154,6 @@ export class ScansComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Callback for temporal filter updating the live range selection.
-     * @param data hours that should be used, or null to clear
-     */
-    onLiveRangeSelected(data: {hours: number}): void {
-        // keep model in sync
-        this.liveRange = data.hours;
-        // patch in the values for datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            liveRange: data.hours
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
      * Callback for when temporal filter tells this component to update visible date range. This is
      * the signal that either a date range or a live range is being triggered.
      * @param data start and end iso strings for what dates should be filtered
@@ -240,14 +213,12 @@ export class ScansComponent implements OnInit, OnDestroy {
                     sortOrder: params.sortOrder ? parseInt(params.sortOrder, 10) : -1,
                     started: params.started || this.datatableOptions.started,
                     ended: params.ended || this.datatableOptions.ended,
-                    liveRange: params.liveRange ? parseInt(params.liveRange, 10) : null,
                     duration: params.duration ? params.duration : null,
                     name: params.name || null
                 };
             }
             this.started = this.datatableOptions.started;
             this.ended = this.datatableOptions.ended;
-            this.liveRange = this.datatableOptions.liveRange;
             this.nameFilterText = this.datatableOptions.name;
             this.updateData();
         });

--- a/projects/developer/src/app/system/scans/component.ts
+++ b/projects/developer/src/app/system/scans/component.ts
@@ -145,6 +145,9 @@ export class ScansComponent implements OnInit, OnDestroy {
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // determine if values have changed
+        const isSame = this.started === data.start && this.ended === data.end;
+
         // keep local model in sync
         this.started = data.start;
         this.ended = data.end;
@@ -154,6 +157,12 @@ export class ScansComponent implements OnInit, OnDestroy {
                 ended: data.end
             });
         this.updateOptions();
+
+        // updateOptions will only cause a data refresh if the route params are different
+        // force a data update only when the params haven't changed
+        if (isSame) {
+            this.updateData();
+        }
     }
 
     onCreateClick(e) {

--- a/projects/developer/src/app/system/scans/component.ts
+++ b/projects/developer/src/app/system/scans/component.ts
@@ -78,7 +78,11 @@ export class ScansComponent implements OnInit, OnDestroy {
         });
     }
     private updateOptions() {
-        this.datatableOptions = _.pickBy(this.datatableOptions, d => {
+        this.datatableOptions = _.pickBy(this.datatableOptions, (d, idx) => {
+            if (idx === 'started' || idx === 'ended') {
+                // allow started and ended to be empty
+                return d;
+            }
             return d !== null && typeof d !== 'undefined' && d !== '';
         });
 
@@ -137,35 +141,19 @@ export class ScansComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Callback for temporal filter updating the start/end range filter.
-     * @param data start and end strings of iso formatted datetimes
-     */
-    onDateFilterSelected(data: {start: string, end: string}): void {
-        // keep local model in sync
-        this.started = data.start;
-        this.ended = data.end;
-        // patch in the values to the datatable
-        this.datatableOptions = Object.assign(this.datatableOptions, {
-            started: data.start,
-            ended: data.end
-        });
-        // update router
-        this.updateOptions();
-    }
-
-    /**
-     * Callback for when temporal filter tells this component to update visible date range. This is
-     * the signal that either a date range or a live range is being triggered.
+     * Callback for when temporal filter tells this component to update visible date range.
      * @param data start and end iso strings for what dates should be filtered
      */
     onTemporalFilterUpdate(data: {start: string, end: string}): void {
+        // keep local model in sync
+        this.started = data.start;
+        this.ended = data.end;
         // update the datatable options then call the api
         this.datatableOptions = Object.assign(this.datatableOptions, {
-                first: 0,
                 started: data.start,
                 ended: data.end
             });
-        this.updateData();
+        this.updateOptions();
     }
 
     onCreateClick(e) {
@@ -199,9 +187,6 @@ export class ScansComponent implements OnInit, OnDestroy {
 
         if (!this.datatableOptions) {
             this.datatableOptions = this.scansDatatableService.getScansDatatableOptions();
-            // let temporal filter set the start/end
-            this.datatableOptions.started = null;
-            this.datatableOptions.ended = null;
         }
         this.scans = [];
         this.route.queryParams.subscribe(params => {
@@ -211,8 +196,8 @@ export class ScansComponent implements OnInit, OnDestroy {
                     rows: params.rows ? parseInt(params.rows, 10) : 10,
                     sortField: params.sortField ? params.sortField : 'last_modified',
                     sortOrder: params.sortOrder ? parseInt(params.sortOrder, 10) : -1,
-                    started: params.started || this.datatableOptions.started,
-                    ended: params.ended || this.datatableOptions.ended,
+                    started: this.datatableOptions.started || params.started,
+                    ended: this.datatableOptions.ended || params.ended,
                     duration: params.duration ? params.duration : null,
                     name: params.name || null
                 };

--- a/projects/developer/src/app/system/scans/datatable.service.ts
+++ b/projects/developer/src/app/system/scans/datatable.service.ts
@@ -23,6 +23,10 @@ export class ScansDatatableService {
 
     setScansDatatableOptions(params: ScansDatatable): void {
         this.scansDatatable = params;
+
+        // don't let started/ended params persist in local storage
+        delete params.started;
+        delete params.ended;
         this.storage.set(params);
     }
 }


### PR DESCRIPTION
Fixes #445 

I think I've captured everything in that issue, but please test out. Big things to test:
- verify live range on dashboard is working as expected
- data tables:
    - data > ingest
    - processing > batches, jobs, and recipes
    - system > scans

The data tables should have:
- new refresh button (not sure about this design)
- clarify the picker is in UTC (I don't like the label, open to ideas)
- allow the user to select no start and/or no end
    - only restriction is not allowing the user to select a start that is past an end
- refreshing with the query params should preserve empty start/end dates
- start/end dates are not persisted at all, except for hitting the browser reload
    - these should default to 24 hours when there are no query params

Your dates may be stuck in persistence mode the first time you load the page, since they were stored in local storage. Either clear local storage first, or ignore it on the first page load.

An image is available at mheppner/scale-ui:issue-445