### PR TITLE
Issue 464 - Data Files table loading spinner persists

### DIFF
--- a/api/handlers/files.js
+++ b/api/handlers/files.js
@@ -53,7 +53,8 @@ module.exports = function(request) {
                 title: "My Other Recipe",
                 description: "Processes some other data",
                 revision_num: 123
-            }
+            },
+            null
         ];
         data.results.push({
             id: id,

--- a/projects/developer/src/app/processing/batches/batch-workflow/batch-workflow.component.spec.ts
+++ b/projects/developer/src/app/processing/batches/batch-workflow/batch-workflow.component.spec.ts
@@ -22,28 +22,4 @@ describe('BatchWorkflowComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-  describe('#getStepHeader', () => {
-
-    it('should return the name of the current step', () => {
-        component.items = [
-            {label: 'Step 1'},
-            {label: 'Step 2'}
-        ];
-        component.activeIndex = 1;
-        expect(component.getStepHeader()).toBe('Step 2');
-    });
-
-    describe('when the step is optional', () => {
-        // Step 1 is optional
-
-        it('should return "(Optional)" in the header',  () => {
-            component.items = [
-                {label: 'Step 1'},
-                {label: 'Step 2'}
-            ];
-            component.activeIndex = 0;
-            expect(component.getStepHeader()).toBe('Step 1 (Optional)');
-        });
-    });
-  });
 });

--- a/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.spec.ts
+++ b/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.spec.ts
@@ -1,25 +1,24 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { DatasetComponent } from './create-dataset.component';
+import { CreateDatasetComponent } from './create-dataset.component';
 
-describe('DatasetComponent', () => {
-  let component: DatasetComponent;
-  let fixture: ComponentFixture<DatasetComponent>;
+describe('CreateDatasetComponent', () => {
+    let component: CreateDatasetComponent;
+    let fixture: ComponentFixture<CreateDatasetComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ DatasetComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [CreateDatasetComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DatasetComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(CreateDatasetComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.ts
+++ b/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.ts
@@ -371,35 +371,8 @@ export class CreateDatasetComponent implements OnInit {
                 this.datasetFilesData = data;
                 this.datasetFileList = data.results;
                 this.filteredDatasetFileList = data.results;
-
-                this.mediaTypeOptions = this.datasetFileList
-                    .map(file => file.media_type)
-                    .filter(onlyUnique)
-                    .map(mediaType => ({
-                        label: mediaType,
-                        value: mediaType
-                    }));
-
-                this.locationOptions = []
-                    .concat(...data.results.map(file => file.countries))
-                    .filter(onlyUnique)
-                    .map(country => ({ label: country, value: country }));
-
-                this.recipeTypeOptions = data.results
-                    .map(file => file.recipe_type)
-                    .filter((obj, pos, arr) => {
-                        return (
-                            arr
-                                .map(mapObj => mapObj['id'])
-                                .indexOf(obj['id']) === pos
-                        );
-                    })
-                    .map(rt => ({
-                        label: `${rt.title} v${rt.revision_num}`,
-                        value: rt
-                    }));
-
                 this.datatableLoading = false;
+                this.buildOptionalFilters(data);
             });
         } else {
             const values = this.form.value;
@@ -411,6 +384,36 @@ export class CreateDatasetComponent implements OnInit {
             this.form.get('searchTime').markAsDirty();
             this.form.updateValueAndValidity();
         }
+    }
+
+    buildOptionalFilters(data: ApiResults) {
+        this.mediaTypeOptions = data.results
+            .map((file) => file.media_type)
+            .filter(onlyUnique)
+            .map((mediaType) => ({
+                label: mediaType,
+                value: mediaType,
+            }));
+
+        this.locationOptions = []
+            .concat(...data.results.map((file) => file.countries))
+            .filter(onlyUnique)
+            .map((country) => ({ label: country, value: country }));
+
+        this.recipeTypeOptions = data.results
+            .reduce((results, file) => {
+                if (file.recipe_type) {
+                    results.push(file.recipe_type);
+                }
+                return results;
+            }, [])
+            .filter((obj, pos, arr) => {
+                return arr.map((mapObj) => mapObj['id']).indexOf(obj['id']) === pos;
+            })
+            .map((rt) => ({
+                label: `${rt.title} v${rt.revision_num}`,
+                value: rt,
+            }));
     }
 
     onDatasetSelectChange(event) {


### PR DESCRIPTION
* Adds null as recipe type to mocks
* Removes getStepHeader test suite since the method no longer exists
* Fixes component import name in specs
* Moves loading state change above optional, filter options building.
* Replaces map with reduce function to check for null recipe_type values before building recipeTypeOptions array.