### PR TITLE
Fixed issue 462 calendars not working in metrics

### DIFF
--- a/projects/developer/src/app/data/metrics/component.scss
+++ b/projects/developer/src/app/data/metrics/component.scss
@@ -1,5 +1,5 @@
 ::ng-deep .metricsDateFilter {
-    z-index: 10021004 !important;
+    z-index: 10022000 !important;
 
     table td {
         padding: 0 !important;


### PR DESCRIPTION
When the sidebar is opened and closed, it increases the z-index, which was hiding the calendar dropdown window beneath the sidebar so it appeared unresponsive.  I increased the z-index for the metricsDateFilter to ensure it stays on top even if the user opens and closes the dropdown window many times.