### PR TITLE
Issue #482 Limit timeline to latest revisions, add option for past revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Change `"apiPrefix"` in `src/assets/appConfig.json` to point to one of these pro
 
 - `/mocks`: built-in development server above with mock data
 - `/local`: a locally installed Scale server
-- `/alpha` and `/omega`: the live test clusters
+- `/alpha` and `/oarfish`: the live test clusters
 
 ## Configuration
 

--- a/projects/developer/src/app/app.component.ts
+++ b/projects/developer/src/app/app.component.ts
@@ -110,7 +110,7 @@ export class AppComponent implements OnInit {
             });
         } else {
             this.isAuthenticated = true;
-            this.globals.is_staff = false;
+            this.globals.is_staff = true;
         }
     }
 }

--- a/projects/developer/src/app/configuration/recipe-types/api.service.ts
+++ b/projects/developer/src/app/configuration/recipe-types/api.service.ts
@@ -83,7 +83,7 @@ export class RecipeTypesApiService {
     }
 
     getRecipeTypeRev(name: string): Observable<any> {
-        return this.http.get<RecipeType>(`${this.apiPrefix}/recipe-types/${name}/revisions`)
+        return this.http.get<RecipeType>(`${this.apiPrefix}/recipe-types/${name}/revisions/`)
         .pipe(
             map(response => {
                 return ApiResults.transformer(response);

--- a/projects/developer/src/app/data/timeline/component.html
+++ b/projects/developer/src/app/data/timeline/component.html
@@ -27,16 +27,16 @@ Visualize the created/deprecated history of job types or recipe types.
     </p-dropdown>
     <div *ngIf="selectedDataTypeOption">
         <label>Types to compare: </label>
-        <p-multiSelect [options]="filterOptions" [(ngModel)]="selectedFilters" 
+        <p-multiSelect [options]="filterOptions" [(ngModel)]="selectedFilters"
                        [style]="{'width':'100%'}" (onChange)="onTypesClick()"></p-multiSelect>
     </div>
-    <div *ngIf="selectedDataTypeOption">
-        <label>Revisions: </label>
-        <p-multiSelect [options]="revisionOptions" [(ngModel)]="selectedRevs"
-                       [style]="{'width':'100%'}" (onChange)="enableButton()"></p-multiSelect>
-    </div>
-    <button pButton type="button" icon="fa fa-refresh" class="timeline__date-filter-btn" label="Update Chart"
+        <p-checkbox [(ngModel)]="includeRevisions"
+        [binary]="true" class="revisions"></p-checkbox>
+        <label class="revisions">&nbsp;&nbsp;Include revisions</label>
+    <div>
+        <button pButton type="button" icon="fa fa-refresh" class="timeline__date-filter-btn" label="Update Chart"
             (click)="onUpdateChartClick()" [disabled]="selectedFilters.length === 0"></button>
+    </div>
 </p-sidebar>
 <div class="timeline__chart">
     <p-chart type="timeline" [options]="options" [data]="data" *ngIf="data" [height]="500" ></p-chart>

--- a/projects/developer/src/app/data/timeline/component.scss
+++ b/projects/developer/src/app/data/timeline/component.scss
@@ -13,6 +13,10 @@ label {
     padding: .2em .6em .1em .6em;
 }
 
+.revisions {
+    display: inline-block;
+}
+
 button {
     margin: 15px 0;
 }

--- a/projects/developer/src/app/data/timeline/component.ts
+++ b/projects/developer/src/app/data/timeline/component.ts
@@ -35,6 +35,7 @@ export class TimelineComponent implements OnInit {
     ];
     selectedDataTypeOption: string;
     filterOptions = [];
+    includeRevisions = false;
     revisionOptions = [];
     selectedFilters = [];
     selectedRevs = [];
@@ -62,14 +63,11 @@ export class TimelineComponent implements OnInit {
     private createTimeline(type) {
         this.showChart = true;
         this.showFilters = false;
-
-
-
         const params = {
             started: this.utcStartDate.toISOString(),
             ended: this.utcEndDate.toISOString(),
             id: this.selectedFilters.map(f => f.id),
-            rev: this.selectedRevs.map(r => r.revision_num)
+            rev: this.selectedRevs.map(r => r.value.revision_num)
         };
 
         if (type === 'Recipe Types') {
@@ -86,7 +84,7 @@ export class TimelineComponent implements OnInit {
             }, err => {
                 console.log(err);
                 this.dataTypesLoading = false;
-                this.messageService.add({severity: 'error', summary: 'Error retrieving job types', detail: err.statusText});
+                this.messageService.add({severity: 'error', summary: 'Error retrieving recipe types', detail: err.statusText});
             });
         } else if (type === 'Job Types') {
             this.timelineApiService.getJobTypeDetails(params).subscribe(data => {
@@ -242,8 +240,8 @@ export class TimelineComponent implements OnInit {
                             value: result
                         });
                     });
+                });
             });
-         });
         } else if (this.selectedDataTypeOption === 'Job Types' ) {
             _.forEach(this.selectedFilters, job => {
                 this.jobTypesApiService.getJobTypeVersions(job.name).subscribe(data => {
@@ -258,7 +256,11 @@ export class TimelineComponent implements OnInit {
         }
         this.enableButton();
     }
-    onUpdateChartClick()  {
+    onUpdateChartClick() {
+        if (this.includeRevisions) {
+           // Include all revisions
+           this.selectedRevs = this.revisionOptions;
+        }
         this.createTimeline(this.selectedDataTypeOption);
     }
 

--- a/projects/developer/src/assets/appConfig.json
+++ b/projects/developer/src/assets/appConfig.json
@@ -1,6 +1,6 @@
 {
     "apiDefaultVersion": "v6",
-    "apiPrefix": "/mocks",
+    "apiPrefix": "/oarfish",
     "apiVersions": [],
     "authEnabled": false,
     "authSchemeType": "external",

--- a/projects/developer/src/assets/appConfig.json
+++ b/projects/developer/src/assets/appConfig.json
@@ -1,6 +1,6 @@
 {
     "apiDefaultVersion": "v6",
-    "apiPrefix": "/oarfish",
+    "apiPrefix": "/mocks",
     "apiVersions": [],
     "authEnabled": false,
     "authSchemeType": "external",

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -21,13 +21,13 @@
             "^/alpha": ""
         }
     },
-    "/omega": {
-        "target": "https://scale.omega.aisohio.net/api",
-        "secure": true,
+    "/oarfish": {
+        "target": "https://scale.oarfish.aisohio.net/api",
+        "secure": false,
         "logLevel": "debug",
         "changeOrigin": true,
         "pathRewrite": {
-            "^/omega": ""
+            "^/oarfish": ""
         }
     }
 }


### PR DESCRIPTION
fix: Limit timeline to latest revisions, add option for past revisions, close #482
Plus change "omega" to "oarfish" in most locations and set default user permissions to "is staff" for local configurations without auth setup.