### PR TITLE
Issue #450 - Better Error Messages

### DIFF
--- a/projects/developer/src/app/configuration/recipe-types/component.ts
+++ b/projects/developer/src/app/configuration/recipe-types/component.ts
@@ -487,7 +487,17 @@ export class RecipeTypesComponent implements OnInit, OnDestroy {
                 this.messageService.add({ severity: 'warn', summary: warning.name, detail: warning.description, sticky: true });
             });
             _.forEach(result.errors, error => {
-                this.messageService.add({ severity: 'error', summary: error.name, detail: error.description, sticky: true });
+                if (error.name.endsWith('JSON')) {
+                    const errors = JSON.parse(error.description);
+                    // Remove the _JSON in the name.
+                    const name = error.name.substring(0, error.name.length - 5);
+
+                    for (const detail of errors) {
+                        this.messageService.add({ severity: 'error', summary: name, detail, sticky: true });
+                    }
+                } else {
+                    this.messageService.add({ severity: 'error', summary: error.name, detail: error.description, sticky: true });
+                }
             });
         }, err => {
             console.log(err);


### PR DESCRIPTION
Add a new recipe invalid definition error 'INVALID_DEFINITION_JSON' to give better and more understandable feedback to the user when multiple validation errors are found.