### PR TITLE
Depreciate filter

### DIFF
--- a/projects/developer/src/app/data/metrics/component.html
+++ b/projects/developer/src/app/data/metrics/component.html
@@ -41,15 +41,18 @@
             <i class="fa fa-circle-o-notch fa-spin"></i>
         </div>
         <div *ngIf="selectedDataType && selectedDataType.name === 'job-types'">
+            <div class="p-field-checkbox">
+                <p-checkbox [(ngModel)]="checked" binary="true" (onChange)="onCheck()" label="Display Depricated Job/Recipe Types"></p-checkbox>
+            </div>
             <label>Recipe Types</label>
-            <p-multiSelect [options]="recipeTypeOptions" [(ngModel)]="selectedRecipeTypes"
+            <p-multiSelect [options]="recipeTypeOptions" [(ngModel)]="selectedRecipeTypes" [dataKey]="'id'"
                            [style]="{'width':'100%'}" (onChange)="getRecipeJobTypes()"></p-multiSelect>
             Select a specific recipe type to view all of its associated job types.
         </div>
         <div *ngIf="filteredChoicesOptions.length > 0">
             <label>{{ dataTypeFilterText }}</label>
-            <p-multiSelect [options]="filteredChoicesOptions" [(ngModel)]="filtersApplied"
-                           (onChange)="colorGenerator($event)" [style]="{'width':'100%'}"> </p-multiSelect>
+            <p-multiSelect [options]="filteredChoicesOptions" [(ngModel)]="filtersApplied" [dataKey]="'id'"
+                           [style]="{'width':'100%'}" (onChange)="colorGenerator($event)"></p-multiSelect>
             To view an aggregate count for the data source, leave this filter unselected.
         </div>
         <div *ngIf="columns.length > 0">

--- a/projects/developer/src/app/data/metrics/component.html
+++ b/projects/developer/src/app/data/metrics/component.html
@@ -42,7 +42,7 @@
         </div>
         <div *ngIf="selectedDataType && selectedDataType.name === 'job-types'">
             <div class="p-field-checkbox">
-                <p-checkbox [(ngModel)]="checked" binary="true" (onChange)="onCheck()" label="Display Depricated Job/Recipe Types"></p-checkbox>
+                <p-checkbox [(ngModel)]="checked" binary="true" (onChange)="onCheck()" label="Display Deprecated Job/Recipe Types"></p-checkbox>
             </div>
             <label>Recipe Types</label>
             <p-multiSelect [options]="recipeTypeOptions" [(ngModel)]="selectedRecipeTypes" [dataKey]="'id'"

--- a/projects/developer/src/app/data/metrics/component.scss
+++ b/projects/developer/src/app/data/metrics/component.scss
@@ -15,6 +15,10 @@
         margin: 15px 0 0 0;
     }
 
+    .p-field-checkbox {
+        margin: 5px 0 15px 0;
+    }
+
     button {
         margin: 15px 0;
     }
@@ -48,5 +52,17 @@
         .ui-panel-content {
             padding: 3px;
         }
+    }
+
+    ::ng-deep .ui-chkbox-label {
+        font-weight: normal;
+        font-size: 12px;
+    }
+
+    ::ng-deep .ui-chkbox-box.ui-state-focus {
+        -moz-box-shadow: none;
+        -webkit-box-shadow: none;
+        box-shadow: none;
+        border-color: #a6a6a6;
     }
 }

--- a/projects/developer/src/app/data/metrics/component.ts
+++ b/projects/developer/src/app/data/metrics/component.ts
@@ -27,11 +27,9 @@ export class MetricsComponent implements OnInit, AfterViewInit {
     availableDataTypes: SelectItem[] = [];
     dataTypesLoading: boolean;
     selectedDataType: any;
-
     checked = false;
-    subscriptions: any[] = [];
-    sub: any;
-
+    recipeSubscription: any;
+    filterSubscription: any;
     filtersApplied = [];
     selectedDataTypeOptions: any = [];
     dataTypeFilterText = '';
@@ -103,9 +101,11 @@ export class MetricsComponent implements OnInit, AfterViewInit {
 
     private getRecipeTypes() {
         const params = { is_active: (this.checked === true) ? null : true };
-        this.subscriptions.forEach(s => s.unsubscribe());
-        this.subscriptions.push(this.recipeTypesApiService.getRecipeTypes(params).subscribe(data => {
-            // unselect depreciated recipes
+        if (this.recipeSubscription != null) {
+            this.recipeSubscription.unsubscribe();
+        }
+        this.recipeSubscription = this.recipeTypesApiService.getRecipeTypes(params).subscribe(data => {
+            // unselect deprecated recipes
             if (this.selectedRecipeTypes != null) {
                 this.selectedRecipeTypes = this.selectedRecipeTypes.filter(selected => {
                     return (selected.is_active === true);
@@ -124,7 +124,7 @@ export class MetricsComponent implements OnInit, AfterViewInit {
         }, err => {
             console.log(err);
             this.messageService.add({severity: 'error', summary: 'Error retrieving recipe types', detail: err.statusText});
-        }));
+        });
     }
 
     colorGenerator(e) {
@@ -169,10 +169,10 @@ export class MetricsComponent implements OnInit, AfterViewInit {
     }
     getDataTypeOptions() {
         this.filteredChoicesLoading = true;
-        if (this.sub != null) {
-            this.sub.unsubscribe();
+        if (this.filterSubscription != null) {
+            this.filterSubscription.unsubscribe();
         }
-        this.sub = this.metricsApiService.getDataTypeOptions(this.selectedDataType.name).subscribe(result => {
+        this.filterSubscription = this.metricsApiService.getDataTypeOptions(this.selectedDataType.name).subscribe(result => {
             this.filteredChoicesLoading = false;
             this.selectedDataTypeOptions = result;
 
@@ -191,7 +191,7 @@ export class MetricsComponent implements OnInit, AfterViewInit {
                     this.dataTypeFilterText + ', ' + _.capitalize(filter.param);
             });
 
-            // unselect depreciated recipes
+            // unselect deprecated recipes
             if (this.filtersApplied != null) {
                 this.filtersApplied = this.filtersApplied.filter(filter => {
                     return (filter.is_active === true);

--- a/projects/developer/src/app/data/timeline/component.html
+++ b/projects/developer/src/app/data/timeline/component.html
@@ -38,9 +38,9 @@ Visualize the created/deprecated history of job types or recipe types.
         [binary]="true" class="checkbox"
         label="Include Revisions"></p-checkbox>
         <!--<label class="revisions">&nbsp;&nbsp;Include revisions</label>-->
-        <p-checkbox [(ngModel)]="showDepricated" 
-        [binary]="true" (onChange)="onShowDepricated()" class="checkbox"
-        label="Display Depricated Job/Recipe Types"></p-checkbox>
+        <p-checkbox [(ngModel)]="showDeprecated" 
+        [binary]="true" (onChange)="onShowDeprecated()" class="checkbox"
+        label="Display Deprecated Job/Recipe Types"></p-checkbox>
     </div>
     <div>
     

--- a/projects/developer/src/app/data/timeline/component.html
+++ b/projects/developer/src/app/data/timeline/component.html
@@ -27,13 +27,23 @@ Visualize the created/deprecated history of job types or recipe types.
     </p-dropdown>
     <div *ngIf="selectedDataTypeOption">
         <label>Types to compare: </label>
-        <p-multiSelect [options]="filterOptions" [(ngModel)]="selectedFilters"
-                       [style]="{'width':'100%'}" (onChange)="onTypesClick()"></p-multiSelect>
+        <div class="timeline__filter-loading" *ngIf="dataTypesLoading">
+            <i class="fa fa-circle-o-notch fa-spin"></i>
+        </div>
+        <p-multiSelect [options]="filterOptions" [(ngModel)]="selectedFilters" [dataKey]="'id'"
+                       [style]="{'width':'100%'}" (onChange)="onTypesClick()" *ngIf="!dataTypesLoading"></p-multiSelect>
     </div>
+    <div class="p-field-checkbox">
         <p-checkbox [(ngModel)]="includeRevisions"
-        [binary]="true" class="revisions"></p-checkbox>
-        <label class="revisions">&nbsp;&nbsp;Include revisions</label>
+        [binary]="true" class="checkbox"
+        label="Include Revisions"></p-checkbox>
+        <!--<label class="revisions">&nbsp;&nbsp;Include revisions</label>-->
+        <p-checkbox [(ngModel)]="showDepricated" 
+        [binary]="true" (onChange)="onShowDepricated()" class="checkbox"
+        label="Display Depricated Job/Recipe Types"></p-checkbox>
+    </div>
     <div>
+    
         <button pButton type="button" icon="fa fa-refresh" class="timeline__date-filter-btn" label="Update Chart"
             (click)="onUpdateChartClick()" [disabled]="selectedFilters.length === 0"></button>
     </div>

--- a/projects/developer/src/app/data/timeline/component.scss
+++ b/projects/developer/src/app/data/timeline/component.scss
@@ -13,8 +13,13 @@ label {
     padding: .2em .6em .1em .6em;
 }
 
-.revisions {
+.p-field-checkbox {
+    margin: 5px 0 15px 0;
+}
+
+.checkbox {
     display: inline-block;
+    padding: 5px 0 0 0;
 }
 
 button {

--- a/projects/developer/src/app/data/timeline/component.ts
+++ b/projects/developer/src/app/data/timeline/component.ts
@@ -38,7 +38,7 @@ export class TimelineComponent implements OnInit {
     typeSubscription: any;
     filterOptions = [];
     includeRevisions = false;
-    showDepricated = false;
+    showDeprecated = false;
     revisionOptions = [];
     selectedFilters = [];
     selectedRevs = [];
@@ -195,7 +195,7 @@ export class TimelineComponent implements OnInit {
         this.dataTypesLoading = true;
         this.filterOptions = [];
         this.enableButton();
-        const params = { page_size: 1000, is_active: (this.showDepricated === true) ? null : true };
+        const params = { page_size: 1000, is_active: (this.showDeprecated === true) ? null : true };
         if (this.previousSelectedDataOption === this.selectedDataTypeOption) {
             this.selectedFilters = this.selectedFilters.filter(selected => {
                 return (selected.is_active === true);
@@ -277,7 +277,7 @@ export class TimelineComponent implements OnInit {
         this.createTimeline(this.selectedDataTypeOption);
     }
 
-    onShowDepricated() {
+    onShowDeprecated() {
         if (this.selectedDataTypeOption) {
             this.getFilterOptions();
         }

--- a/projects/developer/src/app/processing/jobs/component.html
+++ b/projects/developer/src/app/processing/jobs/component.html
@@ -83,6 +83,9 @@
                     <div class="warning-text" *ngIf="rowData.notRetriedTooltip">
                         <span class="fa fa-warning" [pTooltip]="rowData.notRetriedTooltip"></span>
                     </div>
+                    <div class="warning-text" *ngIf="!(rowData.job_type.is_active)">
+                        <span class="fa fa-warning" [pTooltip]="'Job Deprecated'"></span>
+                    </div>
                 </div>
                 <div *ngSwitchCase="'recipe'">
                     <div *ngIf="rowData.recipe">

--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -430,7 +430,6 @@ export class JobsComponent implements OnInit, OnDestroy {
         this.selectedJobType.forEach(selected => {
             this.datatableOptions.job_type_name.push(selected.name);
             this.datatableOptions.job_type_name.push(selected.version);
-            selected=selected;
         });
         this.updateOptions();
     }

--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -162,7 +162,6 @@ export class JobsComponent implements OnInit, OnDestroy {
     }
     private getJobTypes() {
         const params = { page_size: 1000, is_active: (this.showDeprecated === true) ? null : true };
-        console.log(this.selectedJobType);
         this.selectedJobType = this.selectedJobType.filter(selected => {
             return (selected.is_active === true);
         });

--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -88,8 +88,10 @@ export class JobsComponent implements OnInit, OnDestroy {
     ended: string;
     isInitialized = false;
     subscription: any;
+    jobSubscription: any;
     isMobile: boolean;
     actionItems: MenuItem[];
+    showDeprecated = false;
     globals: Globals;
 
     constructor(
@@ -159,8 +161,16 @@ export class JobsComponent implements OnInit, OnDestroy {
         });
     }
     private getJobTypes() {
-        this.selectedJobType = [];
-        this.jobTypesApiService.getJobTypes().subscribe(data => {
+        const params = { page_size: 1000, is_active: (this.showDeprecated === true) ? null : true };
+        console.log(this.selectedJobType);
+        this.selectedJobType = this.selectedJobType.filter(selected => {
+            return (selected.is_active === true);
+        });
+
+        if (this.jobSubscription) {
+            this.jobSubscription.unsubscribe();
+        }
+        this.jobSubscription = this.jobTypesApiService.getJobTypes(params).subscribe(data => {
             this.jobTypes = data.results;
             const selectItems = [];
             _.forEach(this.jobTypes, jobType => {
@@ -175,7 +185,6 @@ export class JobsComponent implements OnInit, OnDestroy {
                     value: jobType,
                     icon: isFavorite ? 'fa fa-star' : ''
                 });
-
                 if (
                     (_.indexOf(this.datatableOptions.job_type_name, jobType.name) >= 0 &&
                     _.indexOf(this.datatableOptions.job_type_version, jobType.version) >= 0) &&
@@ -415,6 +424,26 @@ export class JobsComponent implements OnInit, OnDestroy {
                 this.messageService.add({severity: 'error', summary: 'Error retrieving jobs', detail: err.statusText});
             });
     }
+    matchSelectedData() {
+        this.datatableOptions.job_type_name = [];
+        this.datatableOptions.job_type_version = [];
+        this.selectedJobType.forEach(selected => {
+            this.datatableOptions.job_type_name.push(selected.name);
+            this.datatableOptions.job_type_name.push(selected.version);
+            selected=selected;
+        });
+        this.updateOptions();
+    }
+    onShowDeprecated() {
+        this.showDeprecated = !this.showDeprecated;
+        this.actionItems.forEach(action => {
+            if (action.label === 'Show Deprecated Jobs' || action.label === 'Hide Deprecated Jobs') {
+                action.visible = !action.visible;
+            }
+        });
+        this.getJobTypes();
+        this.matchSelectedData();
+    }
     onSelectedJobTypeClick(jobType) {
         _.remove(this.selectedJobType, jobType);
         this.onJobTypeChange({ value: this.selectedJobType });
@@ -423,6 +452,8 @@ export class JobsComponent implements OnInit, OnDestroy {
         this.actionItems = [
             { label: 'Requeue all', icon: 'fa fa-repeat', command: () => { this.requeueAllConfirm(); } },
             { label: 'Cancel all', icon: 'fa fa-ban', command: () => { this.cancelAllConfirm(); } },
+            { label: 'Show Deprecated Jobs', icon: 'fa fa-eye', visible: true, command: () => { this.onShowDeprecated(); } },
+            { label: 'Hide Deprecated Jobs', icon: 'fa fa-eye-slash', visible: false, command: () => { this.onShowDeprecated(); } }
         ];
 
         this.selectedRows = this.dataService.getSelectedJobRows();


### PR DESCRIPTION
### Changes
 - added checkbox to display or hide deprecated jobs in metrics and timeline
 - added an additional action to display or hide deprecated jobs in the pull down for configuration->jobs
 - added a warning icon to deprecated jobs in the job table

### Descriptions
Addresses the [#1817](https://github.com/ngageoint/scale/issues/1817) issue.