### PR TITLE
ingest details page and other fixes

### DIFF
--- a/projects/developer/src/app/app-routing.module.ts
+++ b/projects/developer/src/app/app-routing.module.ts
@@ -19,6 +19,7 @@ import { BatchesComponent } from './processing/batches/batches-component';
 import { BatchDetailsComponent } from './processing/batches/details.component';
 import { BatchWorkflowComponent } from './processing/batches/batch-workflow/batch-workflow.component';
 import { IngestComponent } from './data/ingest/component';
+import { IngestDetailsComponent } from './data/ingest/details.component';
 import { FeedComponent } from './data/feed/component';
 import { NodesComponent } from './system/nodes/component';
 import { StrikesComponent } from './system/strikes/component';
@@ -146,6 +147,11 @@ const routes: Routes = [
         path: 'data/ingest',
         component: IngestComponent,
         data: {title: 'Ingest Records | Scale'}
+    },
+    {
+        path: 'data/ingest/:id',
+        component: IngestDetailsComponent,
+        data: {title: 'Ingest Details | Scale'}
     },
     {
         path: 'data/metrics',

--- a/projects/developer/src/app/app.module.ts
+++ b/projects/developer/src/app/app.module.ts
@@ -73,6 +73,7 @@ import { FeedComponent } from './data/feed/component';
 import { FooterComponent } from './footer/footer.component';
 import { HealthbarComponent } from './navbar/status/healthbar/healthbar.component';
 import { IngestComponent } from './data/ingest/component';
+import { IngestDetailsComponent } from './data/ingest/details.component';
 import { LoadingIndicatorComponent } from './common/components/loading-indicator/component';
 import { JobActivityComponent } from './dashboard/job-activity/component';
 import { JobDetailsComponent } from './processing/jobs/details.component';
@@ -147,6 +148,7 @@ const appInitializer = (appConfig: AppConfigService) => {
         FooterComponent,
         HealthbarComponent,
         IngestComponent,
+        IngestDetailsComponent,
         JobActivityComponent,
         JobDetailsComponent,
         JobHistoryComponent,

--- a/projects/developer/src/app/common/components/temporal-filter/component.ts
+++ b/projects/developer/src/app/common/components/temporal-filter/component.ts
@@ -156,7 +156,7 @@ export class TemporalFilterComponent implements OnInit {
 
             if (isNil(this.ended)) {
                 // default to the end of today, 23:59:59
-                this.endDate = now.clone().endOf('day').toDate(); //UTCDates.utcDateToLocal(now.clone().endOf('day').toDate());
+                this.endDate = UTCDates.utcDateToLocal(now.clone().endOf('day').toDate());
             } else if (this.ended) {
                 this.endDate = UTCDates.utcDateToLocal(this.ended);
             }

--- a/projects/developer/src/app/common/services/files/api.service.ts
+++ b/projects/developer/src/app/common/services/files/api.service.ts
@@ -45,7 +45,9 @@ export class FilesApiService {
             recipe_node: params.recipe_node,
             recipe_type_id: params.recipe_type_id ? params.recipe_type_id.toString() : null,
             batch_id: params.batch_id ? params.batch_id.toString() : null,
-            file_name: params.file_name
+            file_name: params.file_name,
+            file_type: params.file_type,
+            media_type: params.media_type
         };
         apiParams = _.pickBy(apiParams, d => {
             return d !== null && typeof d !== 'undefined' && d !== '';

--- a/projects/developer/src/app/data/ingest/api.service.ts
+++ b/projects/developer/src/app/data/ingest/api.service.ts
@@ -91,4 +91,14 @@ export class IngestApiService {
                 catchError(DataService.handleError)
             );
     }
+
+    getIngestJobs(id: number): Observable<any> {
+        return this.http.get<any>(`${this.apiPrefix}/ingests/${id}/jobs`)
+            .pipe(
+                map(response => {
+                    return ApiResults.transformer(response);
+                }),
+                catchError(DataService.handleError)
+            );
+    }
 }

--- a/projects/developer/src/app/data/ingest/component.html
+++ b/projects/developer/src/app/data/ingest/component.html
@@ -37,7 +37,7 @@
             <td *ngFor="let col of columns" [ngSwitch]="col.field">
                 <span class="ui-column-title">{{ col.header }}</span>
                 <div *ngSwitchCase="'file_name'">
-                    <a *ngIf="rowData.job" [routerLink]="getJobURL(rowData.job)">
+                    <a *ngIf="rowData.job" [routerLink]="getDetailsURL(rowData)">
                         {{ rowData.file_name }}
                     </a>
                     <span *ngIf="!rowData.job">

--- a/projects/developer/src/app/data/ingest/component.ts
+++ b/projects/developer/src/app/data/ingest/component.ts
@@ -202,11 +202,11 @@ export class IngestComponent implements OnInit, OnDestroy {
         if (!_.find(this.selectedRows, { data: { id: e.data.id } })) {
             this.dataService.setSelectedIngestRows(e);
         }
-        if (e.data.job) {
+        if (e.data) {
             if (e.originalEvent.ctrlKey || e.originalEvent.metaKey) {
-                window.open(`/processing/jobs/${e.data.job.id}`);
+                window.open(`/data/ingest/${e.data.id}`);
             } else {
-                this.router.navigate([`/processing/jobs/${e.data.job.id}`]);
+                this.router.navigate([`/data/ingest/${e.data.id}`]);
             }
         } else {
             this.messageService.add({ severity: 'error', summary: 'Job not found', detail: 'There is no job associated with this ingest' });
@@ -215,11 +215,8 @@ export class IngestComponent implements OnInit, OnDestroy {
             });
         }
     }
-    getJobURL(job: any): string {
-        if (job) {
-            return `/processing/jobs/${job.id}`;
-        }
-        return '';
+    getDetailsURL(row: any): string {
+        return `/data/ingest/${row.id}`;
     }
 
     /**

--- a/projects/developer/src/app/data/ingest/details.component.html
+++ b/projects/developer/src/app/data/ingest/details.component.html
@@ -1,0 +1,65 @@
+<div class="ingest__details" *ngIf="ingest">
+    <h2>
+       {{ ingest.file_path }}
+    </h2>
+    <a routerLink="/data/ingest"><i class="fa fa-caret-left"></i> Ingests List</a>
+    <div class="p-grid">
+        <div class="p-col-12 p-md-12 p-lg-4 p-xl-4 ">
+            <p-panel header="Overview">
+                <p-scrollPanel>
+                    <table class="table table-striped">
+                        <tbody>
+                        <tr>
+                            <td>File Name:</td>
+                            <td>
+                                {{ ingest.file_name }}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Workspace:</td>
+                            <td>
+                                {{ ingest.workspace.title }}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Ingest Time:</td>
+                            <td>
+                                {{ ingest.ingest_started }}
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </p-scrollPanel>
+            </p-panel>
+        </div>
+        <div class="p-col-12 p-md-12 p-lg-8 p-xl-8 ">
+            <p-panel header="Job Executions">
+                <p-scrollPanel>
+                    <dev-loading-indicator [loading]="loadingExecutions"></dev-loading-indicator>
+                    <table class="table">
+                        <thead>
+                        <tr>
+                            <th>Job</th>
+                            <th>Started</th>
+                            <th>Status</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr *ngFor="let job of jobs">
+                                <td>
+                                    <a href="/processing/jobs/{{ job.id }}"> {{ job.job_type.title }} {{ job.job_type.version }} </a>
+                                </td>
+                                <td>
+                                    {{ job.started }}
+                                </td>
+                                <td>
+                                    {{ job.status }}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </p-scrollPanel>
+            </p-panel>
+        </div>
+    </div>
+</div>

--- a/projects/developer/src/app/data/ingest/details.component.scss
+++ b/projects/developer/src/app/data/ingest/details.component.scss
@@ -1,0 +1,52 @@
+.ingest__details {
+    th {
+        font-size: 0.9em;
+    }
+
+    .ingest__io {
+        th, td {
+            font-size: 0.9em;
+        }
+
+        td {
+            border-radius: 5px;
+        }
+    }
+
+    .ingest__latest-exe {
+        button {
+            font-size: 0.8em;
+            padding: 1px;
+            border-radius: 5px;
+        }
+    }
+
+    .ingest__exe {
+        button {
+            font-size: 0.9em;
+            padding: 1px;
+        }
+
+        &:hover {
+            background: var(--main-hover);
+            cursor: pointer;
+
+            td {
+                border-radius: 5px;
+            }
+        }
+    }
+
+    .ingest-details__control-btn {
+        margin-right: 6px;
+    }
+
+    pre {
+        overflow-y: auto;
+    }
+
+    ::ng-deep .ui-scrollpanel {
+        width: 100%;
+        height: 50vh;
+    }
+}

--- a/projects/developer/src/app/data/ingest/details.component.spec.ts
+++ b/projects/developer/src/app/data/ingest/details.component.spec.ts
@@ -1,0 +1,39 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+import { MessageService } from 'primeng/components/common/messageservice';
+
+import { IngestApiService } from './api.service';
+import { DataService } from '../../common/services/data.service';
+import { IngestDetailsComponent } from './details.component';
+
+
+describe('IngestDetailsComponent', () => {
+    let component: IngestDetailsComponent;
+    let fixture: ComponentFixture<IngestDetailsComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [IngestDetailsComponent],
+            imports: [HttpClientTestingModule],
+            providers: [
+                MessageService, IngestApiService, DataService,
+                {provide: ActivatedRoute, useClass: class { navigate = jasmine.createSpy('navigate'); }}
+            ],
+            // Tells the compiler not to error on unknown elements and attributes
+            schemas: [NO_ERRORS_SCHEMA]
+        })
+        .compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(IngestDetailsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should be created', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/projects/developer/src/app/data/ingest/details.component.ts
+++ b/projects/developer/src/app/data/ingest/details.component.ts
@@ -1,0 +1,104 @@
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MessageService } from 'primeng/components/common/messageservice';
+import * as moment from 'moment';
+import * as _ from 'lodash';
+
+import { Ingest } from './api.model';
+import { Job } from '../../processing/jobs/api.model';
+import { IngestApiService } from './api.service';
+import { Globals } from '../../globals';
+
+import { ThemeService } from '../../theme/theme.service';
+import { UIChart } from 'primeng/chart';
+
+@Component({
+    selector: 'dev-ingest-details',
+    templateUrl: './details.component.html',
+    styleUrls: ['./details.component.scss']
+})
+export class IngestDetailsComponent implements OnInit, OnDestroy {
+    @ViewChild('chartDetails', {static: false}) chart: UIChart;
+    themeSubscription: any;
+    subscription: any;
+    ingest: Ingest;
+    jobs: Job[];
+    loading: boolean;
+    loadingExecutions: boolean;
+    exeStatus: string;
+    options: any;
+    hasActiveJobExe: boolean;
+    canRequeue: boolean;
+    logDisplay: boolean;
+    inputClass = 'p-col-12';
+    outputClass = 'p-col-12';
+    globals: Globals;
+
+    constructor(
+        private route: ActivatedRoute,
+        private messageService: MessageService,
+        private ingestApiService: IngestApiService,
+        private themeService: ThemeService,
+        globals: Globals
+    ) {
+        this.globals = globals;
+    }
+
+    private initIngestDetail(data) {
+        this.ingest = data;
+    }
+
+    private getIngestDetail(id: number) {
+        this.loading = true;
+        this.subscription = this.ingestApiService.getIngest(id).subscribe(data => {
+            this.loading = false;
+            this.initIngestDetail(data);
+
+            // get job executions
+            this.loadingExecutions = true;
+            this.hasActiveJobExe = false;
+            this.ingestApiService.getIngestJobs(id)
+                .subscribe(jobsData => {
+                    this.loadingExecutions = false;
+                    this.jobs = jobsData.results //Job.transformer(jobsData.results);
+                    // Order the job-exes by created so index [0] will be the latest.
+                    this.jobs.sort(function(a, b) {
+                        return ('' + a.created).localeCompare(b.created);
+                    });
+                }, err => {
+                    this.loadingExecutions = false;
+                    this.messageService.add({severity: 'error', summary: 'Error retrieving job executions', detail: err.statusText});
+                });
+            }, err => {
+                this.loading = false;
+                this.messageService.add({severity: 'error', summary: 'Error retrieving job details', detail: err.statusText});
+            });
+    }
+
+    getUnicode(code) {
+        return `&#x${code};`;
+    }
+
+    unsubscribe() {
+        if (this.subscription) {
+            this.subscription.unsubscribe();
+        }
+    }
+
+    ngOnInit() {
+        this.options = {
+        };
+
+        if (this.route.snapshot) {
+            const id = +this.route.snapshot.paramMap.get('id');
+            this.getIngestDetail(id);
+        }
+    }
+
+    ngOnDestroy() {
+        this.unsubscribe();
+        if (this.themeSubscription) {
+            this.themeSubscription.unsubscribe();
+        }
+    }
+}

--- a/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.html
+++ b/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.html
@@ -154,8 +154,8 @@
 
     <div *ngIf="datasetFilesData" class="p-col-12">
         <label>
-            <span *ngIf="filteredDatasetFileList.length > 100">Previewing the first 100 files out of {{ totalFiles }} total files to add to the dataset</span>
-            <span *ngIf="filteredDatasetFileList.length < 100 || filteredDatasetFileList.length === 100">Showing all {{ filteredDatasetFileList.length }} files to add to the dataset</span>
+            <span *ngIf="totalFiles > 100">Previewing the first 100 files out of {{ totalFiles }} total files to add to the dataset</span>
+            <span *ngIf="totalFiles <= 100">Showing all {{ filteredDatasetFileList.length }} files to add to the dataset</span>
         </label>
         <p-table [columns]="datasetColumns"
             [value]="filteredDatasetFileList"

--- a/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.ts
+++ b/projects/developer/src/app/processing/batches/batch-workflow/create-dataset/create-dataset.component.ts
@@ -14,6 +14,7 @@ import {
     AbstractControl
 } from '@angular/forms';
 import { onlyUnique } from '../../../../common/utils/filters';
+import { UTCDates } from '../../../../common/utils/utcdates';
 import { ValidationMessages } from '../../../../common/utils/CustomValidation';
 import * as _ from 'lodash';
 import { ApiResults } from 'projects/developer/src/app/common/models/api-results.model';
@@ -103,9 +104,10 @@ export class CreateDatasetComponent implements OnInit {
 
         this.datasetColumns = [
             { field: 'id', header: 'ID', width: '10%' },
+            { field: 'created', header: 'Ingested', width: '15%' },
             { field: 'file_name', header: 'File Name', width: '20%' },
-            { field: 'file_type', header: 'File Type', width: '20%' },
-            { field: 'media_type', header: 'Media Type', width: '30%' },
+            { field: 'file_type', header: 'File Type', width: '15%' },
+            { field: 'media_type', header: 'Media Type', width: '20%' },
             { field: 'countries', header: 'Location(s)', width: '20%' }
         ];
 
@@ -341,20 +343,18 @@ export class CreateDatasetComponent implements OnInit {
     }
 
     createQueryOptions(): any {
-        let options = {};
+        let type = 'ingest'
         if (this.form.get('searchTime').value === 'data') {
-            options = {
-                data_started: this.form.get('startDate').value.toISOString(),
-                data_ended: this.form.get('endDate').value.toISOString(),
-                type: 'data'
-            };
-        } else {
-            options = {
-                created_started: this.form.get('startDate').value.toISOString(),
-                created_ended: this.form.get('endDate').value.toISOString(),
-                type: 'ingest'
-            };
+            type = 'data';
         }
+        let options = {
+            type: type,
+            created_started: UTCDates.localDateToUTC(this.form.get('startDate').value).toISOString(),
+            created_ended: UTCDates.localDateToUTC(this.form.get('endDate').value).toISOString(),
+            file_type: this.dataFilesFilter.file_type,
+            media_type: this.dataFilesFilter.media_type,
+            countries: this.dataFilesFilter.countries
+        };
         return options;
     }
 
@@ -447,6 +447,7 @@ export class CreateDatasetComponent implements OnInit {
             };
         }
         this.filterDataSetFiles();
+        this.onQueryDataFilesClick();
     }
 
     onMediaTypeFilterChange(event) {
@@ -459,6 +460,7 @@ export class CreateDatasetComponent implements OnInit {
             };
         }
         this.filterDataSetFiles();
+        this.onQueryDataFilesClick();
     }
 
     onFileTypeFilterChange(event) {
@@ -471,6 +473,7 @@ export class CreateDatasetComponent implements OnInit {
             };
         }
         this.filterDataSetFiles();
+        this.onQueryDataFilesClick();
     }
 
     setMessage(


### PR DESCRIPTION
    - New page - Ingest File details.  The current ingest files list page allows users to filter ingest files, but clicking on
        on a row redirects to the job details page of the ingest job.  Not useful at all.  Now it directs to the
        new Ingest Details page which shows all jobs executed against the file.
    - Processing Jobs and Ingest Files list pages have a new pad date range button.  Clicking button sets the start day time to midnight,
        and the end day time to one second before midnight.  This is useful to avoid the end date based on current time because
        the page remembers the filters and you will not see incoming jobs which can cause user confusion.
    - Create DataSet fixes and changes
        - File type, Mime type, and country filters are now done with API calls.  Previously it was client side filtering against only
            the top 100 results which did not give an accurate count of what would actually happen when creating the data set
        - Fixed bug where data was not refreshed if a filter was removed
        - Result list header now accurately shows the correct number of total results above 100.  It use to always say 100.
        - Added ingest time to the file result table