### PR TITLE
bugfix - reset page number when date range changes

### DIFF
--- a/projects/developer/src/app/processing/jobs/component.ts
+++ b/projects/developer/src/app/processing/jobs/component.ts
@@ -280,6 +280,7 @@ export class JobsComponent implements OnInit, OnDestroy {
 
         // update the datatable options then call the api
         this.datatableOptions = Object.assign(this.datatableOptions, {
+                first: 0,
                 started: data.start,
                 ended: data.end
             });


### PR DESCRIPTION
reset page number when date range changes.  This has caused confused multiple times, as it is remember when you leave the page and come back as well.